### PR TITLE
fix: correct handling of file uri with one or more slashes (eg file:///).

### DIFF
--- a/src/main/resources/vm/script/datamanagement/deleteFunctions.vm
+++ b/src/main/resources/vm/script/datamanagement/deleteFunctions.vm
@@ -30,8 +30,7 @@ function delete {
         info "delete not supported for girder"
     elif [[ ${URI} == file://* ]]
     then
-        ## use the "#[[don't parse me!]]#" velocity syntax to allow ##
-        local FILENAME=`echo $URI | #[[ sed 's#file://##g'` ]]#
+        local FILENAME=`echo $URI | sed 's%file://*%/%'`
 
         info "Removing local file ${FILENAME}..."
         \rm -f $FILENAME

--- a/src/main/resources/vm/script/datamanagement/downloadFunctions.vm
+++ b/src/main/resources/vm/script/datamanagement/downloadFunctions.vm
@@ -141,8 +141,7 @@ function downloadURI {
 
     if [[ ${URI_LOWER} == file://* ]]
     then
-        ## use the "#[[don't parse me!]]#" velocity syntax to allow ##
-        local FILENAME=`echo $URI | #[[ sed 's#file://##g'` ]]#
+        local FILENAME=`echo $URI | sed 's%file://*%/%'`
         if [ ! -r $FILENAME ]
         then
             error "Input file does not have read permission: $FILENAME"

--- a/src/main/resources/vm/script/datamanagement/uploadFunctions.vm
+++ b/src/main/resources/vm/script/datamanagement/uploadFunctions.vm
@@ -222,8 +222,7 @@ function upload {
         fi
     elif [[ ${URI} == file://* ]]
     then
-        ## use the "#[[don't parse me!]]#" velocity syntax to allow ##
-        local FILENAME=`echo $URI | #[[ sed 's#file://##g'`]]#
+        local FILENAME=`echo $URI | sed 's%file://*%/%'`
         local NAME=`basename ${FILENAME}`
 
         if [ -e $FILENAME ]

--- a/src/test/java/fr/insalyon/creatis/gasw/parser/GaswTemplateTest.java
+++ b/src/test/java/fr/insalyon/creatis/gasw/parser/GaswTemplateTest.java
@@ -188,4 +188,42 @@ class GaswTemplateTest {
         // Then
         assertEquals("girder:/f.tar.gz?opt=val", output);
     }
+
+    @Test
+    @DisplayName("full template, file uri one slash")
+    public void fullTemplateFileUriOneSlash() throws SAXException {
+        // Given
+        String template = "$prefix1$dir1/$na1/$na2.tar.gz$options1";
+        List<String> inputs = Arrays.asList("input1", "input2");
+        List<GaswOutputTemplatePart> templateParts =
+            GaswParser.templateParts(template, inputs);
+        Map<String, String> inputsMap = new HashMap<>();
+        inputsMap.put("input1", "file:/a/b/c");
+        inputsMap.put("input2", "/d/e/f.txt");
+
+        // When
+        String output = GaswParser.parseOutputTemplate(templateParts, inputsMap);
+
+        // Then
+        assertEquals("file:/a/b/c/f.txt.tar.gz", output);
+    }
+
+    @Test
+    @DisplayName("full template, file uri three slashes")
+    public void fullTemplateFileUriThreeSlashes() throws SAXException {
+        // Given
+        String template = "$prefix1$dir1/$na1/$na2.tar.gz$options1";
+        List<String> inputs = Arrays.asList("input1", "input2");
+        List<GaswOutputTemplatePart> templateParts =
+            GaswParser.templateParts(template, inputs);
+        Map<String, String> inputsMap = new HashMap<>();
+        inputsMap.put("input1", "file:///a/b/c");
+        inputsMap.put("input2", "/d/e/f.txt");
+
+        // When
+        String output = GaswParser.parseOutputTemplate(templateParts, inputsMap);
+
+        // Then
+        assertEquals("file:/a/b/c/f.txt.tar.gz", output);
+    }
 }


### PR DESCRIPTION
In the scripts, the test to detect a file uri was correct, accepting one or more slashes.  The sed to remove the uri scheme was only accepting many slashes, and didn't work with only one slash.  This has been corrected.

The sed now uses the '%' as separator.  I checked in the velocity specification that this character has no special meaning.

The java code creating the output file name from the pattern is responsible for the suppression of the multiple slashes.  So an input of file:///a/b.txt is transformed into file:/a/b.txt, which is the given to the scripts.