### PR TITLE
Migration lfc to dfc

### DIFF
--- a/src/main/java/fr/insalyon/creatis/gasw/GaswConfiguration.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/GaswConfiguration.java
@@ -153,7 +153,7 @@ public class GaswConfiguration {
             defaultCPUTime = config.getInt(GaswConstants.LAB_DEFAULT_CPUTIME, 1800);
 
             voName = config.getString(GaswConstants.LAB_VO_NAME, "biomed");
-            voDefaultSE = config.getString(GaswConstants.LAB_VO_DEFAULT_SE, "ccsrm02.in2p3.fr");
+            voDefaultSE = config.getString(GaswConstants.LAB_VO_DEFAULT_SE, "SBG-disk");
             voUseCloseSE = config.getString(GaswConstants.LAB_VO_USE_CLOSE_SE, "\"true\"");
             voLFCHost = config.getString(GaswConstants.LAB_VO_LFC_HOST, "lfc-biomed.in2p3.fr");
 

--- a/src/main/resources/vm/script/datamanagement/deleteFunctions.vm
+++ b/src/main/resources/vm/script/datamanagement/deleteFunctions.vm
@@ -1,21 +1,7 @@
 ## deleteFunctions.vm
 
-## Variables
+## Unused variables:
 ## $failOverEnabled
-
-function deleteFile {
-
-    lcg-del -a $1
-    if [ $? != 0 ]
-    then
-        guid=$(lcg-lg $1)
-        surls=$(lcg-lr $1)
-        for surl in $surls
-        do
-            lcg-uf -v $guid $surl
-        done
-    fi
-}
 
 function delete {
 
@@ -40,18 +26,11 @@ function delete {
 
         if [ "${TEST}" = true ]
         then
-            LFN=${LFN}-uploadTest;
+            LFN=${LFN}-uploadTest
         fi
 
         info "Deleting file ${LFN}..."
-        deleteFile lfn:${LFN}
-
-        #if ( $failOverEnabled )
-        if [ $? != 0 ]
-        then
-            lcg-del --nobdii --defaultsetype srmv2 ${DM_DEST}
-        fi
-        #end
+        dirac-dms-remove-files ${LFN}
     fi
 
     stopLog file_delete

--- a/src/main/resources/vm/script/datamanagement/deleteFunctions.vm
+++ b/src/main/resources/vm/script/datamanagement/deleteFunctions.vm
@@ -21,8 +21,9 @@ function delete {
         info "Removing local file ${FILENAME}..."
         \rm -f $FILENAME
     else
-        ## Extract the path part from the uri.
-        local LFN=`echo "${URI}" | sed -r 's%^\w+://[^/]*(/[^?]+)(\?.*)?$%\1%'`
+        ## Extract the path part from the uri, and sanitize it.
+        ## "//" are not accepted by dirac commands.
+        local LFN=`echo "${URI}" | sed -r -e 's%^\w+://[^/]*(/[^?]+)(\?.*)?$%\1%' -e 's#//#/#g'`
 
         if [ "${TEST}" = true ]
         then

--- a/src/main/resources/vm/script/datamanagement/downloadFunctions.vm
+++ b/src/main/resources/vm/script/datamanagement/downloadFunctions.vm
@@ -8,6 +8,14 @@
 function downloadLFN {
 
     local LFN=$1
+
+    # Sanitize LFN:
+    # - "lfn:" at the beginning is optional for dirac-dms-* commands,
+    #    but does not work as expected with comdirac commands like
+    #    dmkdir.
+    # - "//" are not accepted, neither by dirac-dms-*, nor by dmkdir.
+    LFN=$(echo ${LFN} | sed -r -e 's/^lfn://' -e 's#//#/#g')
+
     local LOCAL=${PWD}/`basename ${LFN}`
 
     info "getting file size and computing sendReceiveTimeout"

--- a/src/main/resources/vm/script/datamanagement/downloadFunctions.vm
+++ b/src/main/resources/vm/script/datamanagement/downloadFunctions.vm
@@ -33,15 +33,15 @@ function downloadLFN {
 
     local totalTimeout=$((${timeout} + ${srmTimeout} + ${sendReceiveTimeout}))
 
-    local LINE="(time dirac-dms-get-file -d -o /Resources/StorageElements/GFAL_TIMEOUT=${totalTimeout} ${LFN})"
+    local LINE="time -p dirac-dms-get-file -d -o /Resources/StorageElements/GFAL_TIMEOUT=${totalTimeout} ${LFN}"
     info ${LINE}
-    ${LINE} &> get-file.log
+    (${LINE}) &> get-file.log
 
     if [ $? = 0 ]
     then
         info "dirac-dms-get-file worked fine"
         local source=$(grep "generating url" get-file.log | tail -1 | sed -r 's/^.* (.*)\.$/\1/')
-        local duration=$(grep -P '^real\t' get-file.log | sed -r 's/real\t//')
+        local duration=$(grep -P '^real[ \t]' get-file.log | sed -r 's/real[ \t]//')
         info "DownloadCommand=dirac-dms-get-file Source=${source} Destination=$(hostname) Size=${size} Time=${duration}"
         RET_VAL=0
     else

--- a/src/main/resources/vm/script/datamanagement/downloadFunctions.vm
+++ b/src/main/resources/vm/script/datamanagement/downloadFunctions.vm
@@ -33,19 +33,23 @@ function downloadLFN {
 
     local totalTimeout=$((${timeout} + ${srmTimeout} + ${sendReceiveTimeout}))
 
-    local LINE="dirac-dms-get-file -o /Resources/StorageElements/GFAL_TIMEOUT=${totalTimeout} ${LFN}"
+    local LINE="(time dirac-dms-get-file -d -o /Resources/StorageElements/GFAL_TIMEOUT=${totalTimeout} ${LFN})"
     info ${LINE}
     ${LINE} &> get-file.log
+
     if [ $? = 0 ]
     then
         info "dirac-dms-get-file worked fine"
-        cat get-file.log
+        local source=$(grep "generating url" get-file.log | tail -1 | sed -r 's/^.* (.*)\.$/\1/')
+        local duration=$(grep -P '^real\t' get-file.log | sed -r 's/real\t//')
+        info "DownloadCommand=dirac-dms-get-file Source=${source} Destination=$(hostname) Size=${size} Time=${duration}"
         RET_VAL=0
     else
         error "dirac-dms-get-file failed"
         error "`cat get-file.log`"
         RET_VAL=1
     fi
+
     \rm get-file.log
     return ${RES_VAL}
 }

--- a/src/main/resources/vm/script/datamanagement/downloadFunctions.vm
+++ b/src/main/resources/vm/script/datamanagement/downloadFunctions.vm
@@ -1,91 +1,46 @@
 ## downloadFunctions.vm
 
-## Variables
-## $timeout, $minAvgDownloadThroughput, $bdiiTimeout, $srmTimeout, $failOverEnabled
-## $failOverHost, $failOverPort, $failOverHome
+## Variables used:
+## $timeout, $minAvgDownloadThroughput, $bdiiTimeout, $srmTimeout
+## Variables received, but no more used:
+## $failOverEnabled, $failOverHost, $failOverPort, $failOverHome
 
 function downloadLFN {
 
     local LFN=$1
     local LOCAL=${PWD}/`basename ${LFN}`
 
-    #hacking LFN for N4U
-    LFN=`echo $LFN | sed s/\\\/grid\\\/vo\\\.neugrid\\\.eu\\\/home\\\/vip/\\\/grid\\\/biomed\\\/creatis\\\/vip/g`
-
     info "getting file size and computing sendReceiveTimeout"
-    size=`lfc-ls -l ${LFN} | awk -F' ' '{print $5}'`
-    sendReceiveTimeout=`echo $[${size}/${minAvgDownloadThroughput}/1024]`
-    if [ "$sendReceiveTimeout" = "" ] || [  $sendReceiveTimeout -le 900 ]; then echo "sendReceiveTimeout empty or too small, setting it to 900s"; sendReceiveTimeout=900; else echo "sendReceiveTimeout is $sendReceiveTimeout"; fi;
+    local size=$(dls -l ${LFN} | awk -F' ' '{print $5}')
+    local sendReceiveTimeout=`echo $[${size}/${minAvgDownloadThroughput}/1024]`
+    if [ "$sendReceiveTimeout" = "" ] || [  $sendReceiveTimeout -le 900 ]
+    then
+        info "sendReceiveTimeout empty or too small, setting it to 900s"
+        sendReceiveTimeout=900
+    else
+        info "sendReceiveTimeout is $sendReceiveTimeout"
+    fi
+
     info "Removing file ${LOCAL} in case it is already here"
     \rm -f ${LOCAL}
 
-    info "Checking if the file is on local SE ${VO_BIOMED_DEFAULT_SE}"
-    local closeSURL=`lcg-lr lfn:${LFN} | grep ${VO_BIOMED_DEFAULT_SE}`
-    if [ "${closeSURL}" != "" ]
-    then
-        info "It is. Trying to download the file from there"
-        LINE="lcg-cp -v --connect-timeout $timeout --sendreceive-timeout $sendReceiveTimeout --bdii-timeout $bdiiTimeout --srm-timeout $srmTimeout ${closeSURL} file:${LOCAL}"
-        info ${LINE}
-        ${LINE} &> lcg-log
-        if [ $? = 0 ]
-        then
-            info "lcg-cp worked fine"
-            lcg_source=`cat lcg-log | awk -F"://" '/Trying SURL srm/ {print $2}' | awk -F"/" '{print $1}'|awk -F":" '{print $1}'`;
-            lcg_destination=`hostname`;
-            lcg_time=`cat lcg-log | awk '/Transfer took/ {print $3$4}'`;
-            info "DownloadCommand=lcg-cp Source=$lcg_source Destination=$lcg_destination Size=$size Time=$lcg_time";
-            if [ "${lcg_source}x" = "x" ] || [ "${lcg_destination}x" = "x" ] || [ "${lcg_time}x" = "x" ]
-            then
-                info "Missing lcg_log info, printing the whole file"
-                cat lcg-log
-            fi
-            return 0
-        else
-            error "It failed, falling back on regular lcg-cp"
-        fi
-    else
-        info "It's not, falling back on regular lcg-cp"
-    fi
+    local totalTimeout=$((${timeout} + ${srmTimeout} + ${sendReceiveTimeout}))
 
-
-    info "Downloading file ${LFN}..."
-    LINE="lcg-cp -v --connect-timeout $timeout --sendreceive-timeout $sendReceiveTimeout --bdii-timeout $bdiiTimeout --srm-timeout $srmTimeout lfn:${LFN} file:${LOCAL}"
+    local LINE="dirac-dms-get-file -o /Resources/StorageElements/GFAL_TIMEOUT=${totalTimeout} ${LFN} ${LOCAL}"
     info ${LINE}
-    ${LINE} &> lcg-log
+    ${LINE} &> get-file.log
     if [ $? = 0 ]
     then
-       info "lcg-cp worked fine"
-       lcg_source=`cat lcg-log | awk -F"://" '/Trying SURL srm/ {print $2}' | awk -F"/" '{print $1}'|awk -F":" '{print $1}'`;
-       lcg_destination=`hostname`;
-       lcg_time=`cat lcg-log | awk '/Transfer took/ {print $3$4}'`;
-       info "DownloadCommand=lcg-cp Source=$lcg_source Destination=$lcg_destination Size=$size Time=$lcg_time";
-       if [ "${lcg_source}x" = "x" ] || [ "${lcg_destination}x" = "x" ] || [ "${lcg_time}x" = "x" ]
-       then
-         info "Missing lcg_log info, printing the whole file"
-         cat lcg-log
-       fi
-
+        info "dirac-dms-get-file worked fine"
+        cat get-file.log
+        RET_VAL=0
     else
-#if( $failOverEnabled )
-        local FILENAME=`lcg-lr lfn:${LFN} | grep $failOverHost`
-        #set( $generated = '${FILENAME#*generated}' )
-        local PFILE=${generated}
-        lcg-cp --nobdii --defaultsetype srmv2 -v srm://$failOverHost:$failOverPort/srm/managerv2?SFN=$failOverHome${PFILE} file:`pwd`/`basename ${LFN}`
-        if [ $? = 0 ]
-        then
-            info "lcg-cp from Fail Over server worked fine"
-        else
-            error "lcg-cp failed"
-            error "`cat lcg-log`"
-            return 1
-        fi
-#else
-        error "lcg-cp failed"
-        error "`cat lcg-log`"
-        return 1
-#end
+        error "dirac-dms-get-file failed"
+        error "`cat get-file.log`"
+        RET_VAL=1
     fi
-    \rm lcg-log
+    \rm get-file.log
+    return ${RES_VAL}
 }
 export -f downloadLFN
 

--- a/src/main/resources/vm/script/datamanagement/downloadFunctions.vm
+++ b/src/main/resources/vm/script/datamanagement/downloadFunctions.vm
@@ -11,7 +11,7 @@ function downloadLFN {
     local LOCAL=${PWD}/`basename ${LFN}`
 
     info "getting file size and computing sendReceiveTimeout"
-    local size=$(dls -l ${LFN} | awk -F' ' '{print $5}')
+    local size=$(dirac-dms-lfn-metadata ${LFN} | grep Size | sed -r 's/.* ([0-9]+)L,/\1/')
     local sendReceiveTimeout=`echo $[${size}/${minAvgDownloadThroughput}/1024]`
     if [ "$sendReceiveTimeout" = "" ] || [  $sendReceiveTimeout -le 900 ]
     then

--- a/src/main/resources/vm/script/datamanagement/downloadFunctions.vm
+++ b/src/main/resources/vm/script/datamanagement/downloadFunctions.vm
@@ -16,8 +16,6 @@ function downloadLFN {
     # - "//" are not accepted, neither by dirac-dms-*, nor by dmkdir.
     LFN=$(echo ${LFN} | sed -r -e 's/^lfn://' -e 's#//#/#g')
 
-    local LOCAL=${PWD}/`basename ${LFN}`
-
     info "getting file size and computing sendReceiveTimeout"
     local size=$(dirac-dms-lfn-metadata ${LFN} | grep Size | sed -r 's/.* ([0-9]+)L,/\1/')
     local sendReceiveTimeout=`echo $[${size}/${minAvgDownloadThroughput}/1024]`
@@ -29,12 +27,13 @@ function downloadLFN {
         info "sendReceiveTimeout is $sendReceiveTimeout"
     fi
 
+    local LOCAL=${PWD}/`basename ${LFN}`
     info "Removing file ${LOCAL} in case it is already here"
     \rm -f ${LOCAL}
 
     local totalTimeout=$((${timeout} + ${srmTimeout} + ${sendReceiveTimeout}))
 
-    local LINE="dirac-dms-get-file -o /Resources/StorageElements/GFAL_TIMEOUT=${totalTimeout} ${LFN} ${LOCAL}"
+    local LINE="dirac-dms-get-file -o /Resources/StorageElements/GFAL_TIMEOUT=${totalTimeout} ${LFN}"
     info ${LINE}
     ${LINE} &> get-file.log
     if [ $? = 0 ]

--- a/src/main/resources/vm/script/datamanagement/uploadFunctions.vm
+++ b/src/main/resources/vm/script/datamanagement/uploadFunctions.vm
@@ -1,7 +1,9 @@
 ## uploadFunctions.vm
 
-## Variables
-## $timeout, $minAvgDownloadThroughput, $bdiiTimeout, $srmTimeout, $failOverEnabled
+## Variables used:
+## $timeout, $minAvgDownloadThroughput, $bdiiTimeout, $srmTimeout
+## Variables received, but no more used:
+## $failOverEnabled
 
 function nSEs {
 
@@ -78,9 +80,17 @@ function uploadLfnFile {
     info "getting file size and computing sendReceiveTimeout"
     size=`ls -l ${FILE} | awk -F' ' '{print $5}'`
     sendReceiveTimeout=`echo $[${size}/${minAvgDownloadThroughput}/1024]`
-    if [ "$sendReceiveTimeout" = "" ] || [  $sendReceiveTimeout -le 900 ]; then echo "sendReceiveTimeout empty or too small, setting it to 900s"; sendReceiveTimeout=900; else echo "sendReceiveTimeout is $sendReceiveTimeout"; fi;
+    if [ "$sendReceiveTimeout" = "" ] || [  $sendReceiveTimeout -le 900 ]
+    then
+        info "sendReceiveTimeout empty or too small, setting it to 900s"
+        sendReceiveTimeout=900
+    else
+        info "sendReceiveTimeout is $sendReceiveTimeout"
+    fi
 
-    local OPTS="--connect-timeout $timeout --sendreceive-timeout $sendReceiveTimeout --bdii-timeout $bdiiTimeout --srm-timeout $srmTimeout"
+    local totalTimeout=$((${timeout} + ${srmTimeout} + ${sendReceiveTimeout}))
+
+    local OPTS="-o /Resources/StorageElements/GFAL_TIMEOUT=${totalTimeout}"
     local DEST=""
     if [ "${USE_CLOSE_SE}" = "true" ] && [ "${VO_BIOMED_DEFAULT_SE}" != "" ]
     then
@@ -94,49 +104,19 @@ function uploadLfnFile {
     do
         if [ "${done}" = "0" ]
         then
-            lcg-del -v -a ${OPTS} lfn:${LFN} &>/dev/null
-            lfc-ls ${LFN}
-            if [ $? = 0 ]
-            then
-                lfc-rename ${LFN} ${LFN}-garbage-${HOSTNAME}-${PWD}
-            fi
-            flag="cr"
-            lfc-mkdir -p `dirname ${LFN}`
-            lcg-cr -v ${OPTS} -d ${DEST} -l lfn:${LFN} file:${FILE} &> lcg-log
+            dirac-dms-clean-directory ${OPTS} ${LFN} &>/dev/null
+            dmkdir `dirname ${LFN}`
+            dirac-dms-add-file ${OPTS} ${LFN} ${FILE} ${DEST} &> dirac.log
         else
-            flag="rep"
-            lcg-rep -v ${OPTS} -d ${DEST} lfn:${LFN} &> lcg-log
+            dirac-dms-replicate-lfn ${OPTS} ${LFN} ${DEST} &> dirac.log
         fi
         if [ $? = 0 ]
         then
-            info "lcg-cr/rep of ${LFN} to SE ${DEST} worked fine"
+            info "Copy/Replication of ${LFN} to SE ${DEST} worked fine"
             done=`expr ${done} + 1`
-                    if [ $flag = "cr" ]
-            then
-                lcg_source=`hostname`
-                lcg_destination=$DEST
-                lcg_time=`cat lcg-log | awk '/Transfer took/ {print $3$4}'`
-                info "UploadCommand=lcg-cr Source=$lcg_source Destination=$lcg_destination Size=$size Time=$lcg_time"
-                if [ "${lcg_source}x" = "x" ] || [ "${lcg_destination}x" = "x" ] || [ "${lcg_time}x" = "x" ]
-                then
-                        info "Missing lcg_log info, printing the whole file"
-                        cat lcg-log
-                fi
-
-            else
-                lcg_source=`cat lcg-log | awk -F"://" '/Trying SURL srm/ {print $2}' | awk -F"/" '{print $1}'|awk -F":" '{print $1}'`
-                lcg_destination=$DEST
-                lcg_time=`cat lcg-log | awk '/Transfer took/ {print $3$4}'`
-                info "UploadCommand=lcg-rep Source=$lcg_source Destination=$lcg_destination Size=$size Time=$lcg_time"
-                if [ "${lcg_source}x" = "x" ] || [ "${lcg_destination}x" = "x" ] || [ "${lcg_time}x" = "x" ]
-                then
-                        info "Missing lcg_log info, printing the whole file"
-                        cat lcg-log
-                fi
-            fi
         else
             error "`cat lcg-log`"
-            warning "lcg-cr/rep of ${LFN} to SE ${DEST} failed"
+            warning "Copy/Replication of ${LFN} to SE ${DEST} failed"
         fi
         \rm lcg-log
         chooseRandomSE
@@ -144,21 +124,9 @@ function uploadLfnFile {
     done
     if [ "${done}" = "0" ]
     then
-#if( $failOverEnabled )
-        addToFailOver ${LFN} ${FILE}
-        if [ $? = 0 ]
-        then
-            addToCache ${LFN} ${FILE}
-        else
-            error "Cannot lcg-cr file ${FILE} to lfn ${LFN}"
-            error "Exiting with return value 2"
-            exit 2
-        fi
-#else
-        error "Cannot lcg-cr file ${FILE} to lfn ${LFN}"
+        error "Cannot copy file ${FILE} to lfn ${LFN}"
         error "Exiting with return value 2"
         exit 2
-#end
     else
         addToCache ${LFN} ${FILE}
     fi

--- a/src/main/resources/vm/script/datamanagement/uploadFunctions.vm
+++ b/src/main/resources/vm/script/datamanagement/uploadFunctions.vm
@@ -92,8 +92,7 @@ function uploadLfnFile {
     do
         if [ "${done}" = "0" ]
         then
-            dirac-dms-clean-directory ${OPTS} ${LFN} &>/dev/null
-            dmkdir `dirname ${LFN}`
+            dirac-dms-remove-files ${OPTS} ${LFN} &>/dev/null
             local command="dirac-dms-add-file"
             (time dirac-dms-add-file ${OPTS} ${LFN} ${FILE} ${DEST}) &> dirac.log
         else

--- a/src/main/resources/vm/script/datamanagement/uploadFunctions.vm
+++ b/src/main/resources/vm/script/datamanagement/uploadFunctions.vm
@@ -115,10 +115,10 @@ function uploadLfnFile {
             info "Copy/Replication of ${LFN} to SE ${DEST} worked fine"
             done=`expr ${done} + 1`
         else
-            error "`cat lcg-log`"
+            error "`cat dirac.log`"
             warning "Copy/Replication of ${LFN} to SE ${DEST} failed"
         fi
-        \rm lcg-log
+        \rm dirac.log
         chooseRandomSE
         DEST=${RESULT}
     done

--- a/src/main/resources/vm/script/datamanagement/uploadFunctions.vm
+++ b/src/main/resources/vm/script/datamanagement/uploadFunctions.vm
@@ -85,8 +85,8 @@ function uploadLfnFile {
     LFN=$(echo ${LFN} | sed -r -e 's/^lfn://' -e 's#//#/#g')
 
     info "getting file size and computing sendReceiveTimeout"
-    size=`ls -l ${FILE} | awk -F' ' '{print $5}'`
-    sendReceiveTimeout=`echo $[${size}/${minAvgDownloadThroughput}/1024]`
+    local size=`ls -l ${FILE} | awk -F' ' '{print $5}'`
+    local sendReceiveTimeout=`echo $[${size}/${minAvgDownloadThroughput}/1024]`
     if [ "$sendReceiveTimeout" = "" ] || [  $sendReceiveTimeout -le 900 ]
     then
         info "sendReceiveTimeout empty or too small, setting it to 900s"
@@ -106,7 +106,7 @@ function uploadLfnFile {
         chooseRandomSE
         DEST=${RESULT}
     fi
-    done=0
+    local done=0
     while [ $nrep -gt $done ] && [ "${DEST}" != "" ]
     do
         if [ "${done}" = "0" ]

--- a/src/main/resources/vm/script/datamanagement/uploadFunctions.vm
+++ b/src/main/resources/vm/script/datamanagement/uploadFunctions.vm
@@ -113,14 +113,23 @@ function uploadLfnFile {
         then
             dirac-dms-clean-directory ${OPTS} ${LFN} &>/dev/null
             dmkdir `dirname ${LFN}`
-            dirac-dms-add-file ${OPTS} ${LFN} ${FILE} ${DEST} &> dirac.log
+            local command="dirac-dms-add-file"
+            (time dirac-dms-add-file ${OPTS} ${LFN} ${FILE} ${DEST}) &> dirac.log
         else
-            dirac-dms-replicate-lfn ${OPTS} ${LFN} ${DEST} &> dirac.log
+            local command="dirac-dms-replicate-lfn"
+            (time dirac-dms-replicate-lfn ${OPTS} ${LFN} ${DEST}) &> dirac.log
         fi
         if [ $? = 0 ]
         then
-            info "Copy/Replication of ${LFN} to SE ${DEST} worked fine"
+            info "Copy/Replication of ${LFN} to SE ${DEST} worked fine."
             done=`expr ${done} + 1`
+            local duration=$(grep -P '^real\t' dirac.log | sed -r 's/real\t//')
+            info "UploadCommand=${command} Source=${LFN} Destination=${DEST} Size=${size} Time=${duration}"
+            if [ -z "${duration}" ]
+            then
+                info "Missing duration info, printing the whole log file."
+                cat dirac.log
+            fi
         else
             error "`cat dirac.log`"
             warning "Copy/Replication of ${LFN} to SE ${DEST} failed"

--- a/src/main/resources/vm/script/datamanagement/uploadFunctions.vm
+++ b/src/main/resources/vm/script/datamanagement/uploadFunctions.vm
@@ -92,17 +92,20 @@ function uploadLfnFile {
     do
         if [ "${done}" = "0" ]
         then
-            dirac-dms-remove-files ${OPTS} ${LFN} &>/dev/null
-            (time dirac-dms-add-file ${OPTS} ${LFN} ${FILE} ${DEST}) &> dirac.log
             local command="dirac-dms-add-file"
             local source=$(hostname)
+            dirac-dms-remove-files ${OPTS} ${LFN} &>/dev/null
+            (time dirac-dms-add-file ${OPTS} ${LFN} ${FILE} ${DEST}) &> dirac.log
+            local error_code=$?
         else
-            (time dirac-dms-replicate-lfn -d ${OPTS} ${LFN} ${DEST}) &> dirac.log
             local command="dirac-dms-replicate-lfn"
+            (time dirac-dms-replicate-lfn -d ${OPTS} ${LFN} ${DEST}) &> dirac.log
+            local error_code=$?
+
             # Extract the name of the source SE from the logs.
             local source=$(grep "operation 'getFileSize'" dirac.log | tail -1 | sed -r 's/^.* StorageElement (.*) is .*$/\1/')
         fi
-        if [ $? = 0 ]
+        if [ ${error_code} = 0 ]
         then
             info "Copy/Replication of ${LFN} to SE ${DEST} worked fine."
             done=`expr ${done} + 1`

--- a/src/main/resources/vm/script/datamanagement/uploadFunctions.vm
+++ b/src/main/resources/vm/script/datamanagement/uploadFunctions.vm
@@ -77,6 +77,13 @@ function uploadLfnFile {
     local nrep=$3
     local SELIST=${SE}
 
+    # Sanitize LFN:
+    # - "lfn:" at the beginning is optional for dirac-dms-* commands,
+    #    but does not work as expected with comdirac commands like
+    #    dmkdir.
+    # - "//" are not accepted, neither by dirac-dms-*, nor by dmkdir.
+    LFN=$(echo ${LFN} | sed -r -e 's/^lfn://' -e 's#//#/#g')
+
     info "getting file size and computing sendReceiveTimeout"
     size=`ls -l ${FILE} | awk -F' ' '{print $5}'`
     sendReceiveTimeout=`echo $[${size}/${minAvgDownloadThroughput}/1024]`

--- a/src/main/resources/vm/script/datamanagement/uploadFunctions.vm
+++ b/src/main/resources/vm/script/datamanagement/uploadFunctions.vm
@@ -51,25 +51,6 @@ function chooseRandomSE {
     fi
 }
 
-function renameLfnFile {
-
-    local FROM=$1
-    local TO=$2
-
-    info "Renaming ${FROM} to ${TO}"
-    lfc-ls ${TO}
-    if [ $? != 0 ]
-    then
-        lfc-rename ${FROM} ${TO}
-        if [ $? != 0 ]
-        then
-            exit 2
-        fi
-    else
-        deleteFile lfn:${FROM}
-    fi
-}
-
 function uploadLfnFile {
 
     local LFN=$1
@@ -240,8 +221,7 @@ function upload {
             echo "test result" > ${NAME}
         fi
 
-        uploadLfnFile ${LFN}${ID} ${PWD}/${NAME} ${NREP}
-        renameLfnFile ${LFN}${ID} ${LFN}
+        uploadLfnFile ${LFN} ${PWD}/${NAME} ${NREP}
 
         if [ "${TEST}" = "true" ]
         then

--- a/src/main/resources/vm/script/datamanagement/uploadFunctions.vm
+++ b/src/main/resources/vm/script/datamanagement/uploadFunctions.vm
@@ -95,11 +95,11 @@ function uploadLfnFile {
             local command="dirac-dms-add-file"
             local source=$(hostname)
             dirac-dms-remove-files ${OPTS} ${LFN} &>/dev/null
-            (time dirac-dms-add-file ${OPTS} ${LFN} ${FILE} ${DEST}) &> dirac.log
+            (time -p dirac-dms-add-file ${OPTS} ${LFN} ${FILE} ${DEST}) &> dirac.log
             local error_code=$?
         else
             local command="dirac-dms-replicate-lfn"
-            (time dirac-dms-replicate-lfn -d ${OPTS} ${LFN} ${DEST}) &> dirac.log
+            (time -p dirac-dms-replicate-lfn -d ${OPTS} ${LFN} ${DEST}) &> dirac.log
             local error_code=$?
 
             # Extract the name of the source SE from the logs.
@@ -109,7 +109,7 @@ function uploadLfnFile {
         then
             info "Copy/Replication of ${LFN} to SE ${DEST} worked fine."
             done=`expr ${done} + 1`
-            local duration=$(grep -P '^real\t' dirac.log | sed -r 's/real\t//')
+            local duration=$(grep -P '^real[ \t]' dirac.log | sed -r 's/real[ \t]//')
             info "UploadCommand=${command} Source=${source} Destination=${DEST} Size=${size} Time=${duration}"
             if [ -z "${duration}" ]
             then

--- a/src/main/resources/vm/script/datamanagement/uploadFunctions.vm
+++ b/src/main/resources/vm/script/datamanagement/uploadFunctions.vm
@@ -93,18 +93,21 @@ function uploadLfnFile {
         if [ "${done}" = "0" ]
         then
             dirac-dms-remove-files ${OPTS} ${LFN} &>/dev/null
-            local command="dirac-dms-add-file"
             (time dirac-dms-add-file ${OPTS} ${LFN} ${FILE} ${DEST}) &> dirac.log
+            local command="dirac-dms-add-file"
+            local source=$(hostname)
         else
+            (time dirac-dms-replicate-lfn -d ${OPTS} ${LFN} ${DEST}) &> dirac.log
             local command="dirac-dms-replicate-lfn"
-            (time dirac-dms-replicate-lfn ${OPTS} ${LFN} ${DEST}) &> dirac.log
+            # Extract the name of the source SE from the logs.
+            local source=$(grep "operation 'getFileSize'" dirac.log | tail -1 | sed -r 's/^.* StorageElement (.*) is .*$/\1/')
         fi
         if [ $? = 0 ]
         then
             info "Copy/Replication of ${LFN} to SE ${DEST} worked fine."
             done=`expr ${done} + 1`
             local duration=$(grep -P '^real\t' dirac.log | sed -r 's/real\t//')
-            info "UploadCommand=${command} Source=${LFN} Destination=${DEST} Size=${size} Time=${duration}"
+            info "UploadCommand=${command} Source=${source} Destination=${DEST} Size=${size} Time=${duration}"
             if [ -z "${duration}" ]
             then
                 info "Missing duration info, printing the whole log file."

--- a/src/main/resources/vm/script/execution/result.vm
+++ b/src/main/resources/vm/script/execution/result.vm
@@ -19,7 +19,9 @@ $serviceCall ${MOTEUR_WORKFLOWID} ${JOBID} 5
         #set( $uploadsList = $URI )
     #end
 
-upload "$URI" "`tr -dc "[:alpha:]" < /dev/urandom | head -c 32`" $upload.NumberOfReplicas false
+# Redirecting tr errors to /dev/null to avoid sometimes a normal
+# broken pipe error.
+upload "$URI" "`tr -dc "[:alpha:]" < /dev/urandom 2>/dev/null | head -c 32`" $upload.NumberOfReplicas false
 #end
 
 __MOTEUR_OUT="$uploadsList"


### PR DESCRIPTION
- use of dirac-dms-* commands, as they accept an option to set a timeout.  No comdirac command is used.
- calculation of timeout, depending on the file size.  bdii timeout is ignored.
- removed code concerning N4U.
- removed code handling failover.
- variable VO_BIOMED_DEFAULT_SE and configuration value "vo.default.se" must now be set to SE names for dirac.