### PR TITLE
fix: correct interaction between $ for velocity and for bash.

### DIFF
--- a/src/main/resources/vm/script/datamanagement/downloadFunctions.vm
+++ b/src/main/resources/vm/script/datamanagement/downloadFunctions.vm
@@ -18,8 +18,11 @@ function downloadLFN {
 
     info "getting file size and computing sendReceiveTimeout"
     local size=$(dirac-dms-lfn-metadata ${LFN} | grep Size | sed -r 's/.* ([0-9]+)L,/\1/')
-    local sendReceiveTimeout=`echo $[${size:-0}/${minAvgDownloadThroughput}/1024]`
-    if [ "$sendReceiveTimeout" = "" ] || [  $sendReceiveTimeout -le 900 ]
+    ## The $ sign must not be interpreted by velocity in the following
+    ## shell line.
+    #set ( $D = '$' )
+    local sendReceiveTimeout=`echo ${D}[${D}{size:-0}/${minAvgDownloadThroughput}/1024]`
+    if [ "$sendReceiveTimeout" = "" ] || [ $sendReceiveTimeout -le 900 ]
     then
         info "sendReceiveTimeout empty or too small, setting it to 900s"
         sendReceiveTimeout=900

--- a/src/main/resources/vm/script/datamanagement/uploadFunctions.vm
+++ b/src/main/resources/vm/script/datamanagement/uploadFunctions.vm
@@ -67,8 +67,11 @@ function uploadLfnFile {
 
     info "getting file size and computing sendReceiveTimeout"
     local size=`ls -l ${FILE} | awk -F' ' '{print $5}'`
-    local sendReceiveTimeout=`echo $[${size:-0}/${minAvgDownloadThroughput}/1024]`
-    if [ "$sendReceiveTimeout" = "" ] || [  $sendReceiveTimeout -le 900 ]
+    ## The $ sign must not be interpreted by velocity in the following
+    ## shell line.
+    #set ( $D = '$' )
+    local sendReceiveTimeout=`echo ${D}[${D}{size:-0}/${minAvgDownloadThroughput}/1024]`
+    if [ "$sendReceiveTimeout" = "" ] || [ $sendReceiveTimeout -le 900 ]
     then
         info "sendReceiveTimeout empty or too small, setting it to 900s"
         sendReceiveTimeout=900

--- a/src/test/java/fr/insalyon/creatis/gasw/script/DataManagementGeneratorTest.java
+++ b/src/test/java/fr/insalyon/creatis/gasw/script/DataManagementGeneratorTest.java
@@ -1,0 +1,119 @@
+/* Copyright CNRS-CREATIS
+ *
+ * Rafael Ferreira da Silva
+ * rafael.silva@creatis.insa-lyon.fr
+ * http://www.rafaelsilva.com
+ *
+ * This software is governed by the CeCILL  license under French law and
+ * abiding by the rules of distribution of free software.  You can  use,
+ * modify and/ or redistribute the software under the terms of the CeCILL
+ * license as circulated by CEA, CNRS and INRIA at the following URL
+ * "http://www.cecill.info".
+ *
+ * As a counterpart to the access to the source code and  rights to copy,
+ * modify and redistribute granted by the license, users are provided only
+ * with a limited warranty  and the software's author,  the holder of the
+ * economic rights,  and the successive licensors  have only  limited
+ * liability.
+ *
+ * In this respect, the user's attention is drawn to the risks associated
+ * with loading,  using,  modifying and/or developing or reproducing the
+ * software by the user in light of its specific status of free software,
+ * that may mean  that it is complicated to manipulate,  and  that  also
+ * therefore means  that it is reserved for developers  and  experienced
+ * professionals having in-depth computer knowledge. Users are therefore
+ * encouraged to load and test the software's suitability as regards their
+ * requirements in conditions enabling the security of their systems and/or
+ * data to be ensured and,  more generally, to use and operate it in the
+ * same conditions as regards security.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL license and that you accept its terms.
+ */
+package fr.insalyon.creatis.gasw.script;
+
+import fr.insalyon.creatis.gasw.util.VelocityUtil;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@DisplayName("Check velocity templates")
+class DataManagementGeneratorTest {
+
+    @Test
+    @DisplayName("Check checkCacheDownloadAndCacheLFNFunction template")
+    public void checkCheckCacheDownloadAndCacheLFNFunctionTemplate()
+        throws Exception {
+
+        VelocityUtil velocity = new VelocityUtil("vm/script/datamanagement/checkCacheDownloadAndCacheLFNFunction.vm");
+
+        velocity.put("cacheDir", "dir");
+        velocity.put("cacheFile", "file");
+
+        velocity.merge().toString();
+    }
+
+    @Test
+    @DisplayName("Check downloadFunction template")
+    public void checkDownloadFunctionTemplate() throws Exception {
+        VelocityUtil velocity = new VelocityUtil("vm/script/datamanagement/downloadFunctions.vm");
+
+        velocity.put("timeout", 10);
+        velocity.put("minAvgDownloadThroughput", 10);
+        velocity.put("bdiiTimeout", 10);
+        velocity.put("srmTimeout", 10);
+        velocity.put("failOverEnabled", false);
+        velocity.put("failOverHost", "host");
+        velocity.put("failOverPort", 10);
+        velocity.put("failOverHome", "home");
+
+        velocity.merge().toString();
+    }
+
+    @Test
+    @DisplayName("Check addToCacheFunction template")
+    public void checkAddToCacheFunctionTemplate() throws Exception {
+        VelocityUtil velocity = new VelocityUtil("vm/script/datamanagement/addToCacheFunction.vm");
+
+        velocity.put("cacheDir", "dir");
+        velocity.put("cacheFile", "file");
+
+        velocity.merge().toString();
+    }
+
+    @Test
+    @DisplayName("Check addToFailOverFunction template")
+    public void checkAddToFailOverFunctionTemplate() throws Exception {
+        VelocityUtil velocity = new VelocityUtil("vm/script/datamanagement/addToFailOverFunction.vm");
+
+        velocity.put("failOverHost", "host");
+        velocity.put("failOverPort", 10);
+        velocity.put("failOverHome", "home");
+
+        velocity.merge().toString();
+    }
+
+    @Test
+    @DisplayName("Check uploadFunction template")
+    public void checkUploadFunctionTemplate() throws Exception {
+        VelocityUtil velocity = new VelocityUtil("vm/script/datamanagement/uploadFunctions.vm");
+
+        velocity.put("timeout", 10);
+        velocity.put("minAvgDownloadThroughput", 10);
+        velocity.put("bdiiTimeout", 10);
+        velocity.put("srmTimeout", 10);
+        velocity.put("failOverEnabled", false);
+
+        velocity.merge().toString();
+    }
+
+    @Test
+    @DisplayName("Check deleteFunctions template")
+    public void checkDeleteFunctionsTemplate() throws Exception {
+        VelocityUtil velocity = new VelocityUtil("vm/script/datamanagement/deleteFunctions.vm");
+
+        velocity.merge().toString();
+    }
+}


### PR DESCRIPTION
The $ destinated to bash must be escaped one way or another in
velocity.  We use #set ( D='$' ) and ${D} as recommended in the
velocity documentation.

Added unit tests for the velocity templates concerning data management generator.