### PR TITLE
gfal support 

### DIFF
--- a/src/main/resources/vm/script/basic/cleanupFunction.vm
+++ b/src/main/resources/vm/script/basic/cleanupFunction.vm
@@ -4,9 +4,10 @@
 ## $cacheDir, $cacheFile
 
 function cleanup {
-    if [[ $mountGfal -eq 1 ]]    #flag checks if directories are mounted with gfal
+    if [[ $isGfalmountExec -eq 0 ]]    #flag checks if directories are mounted with gfal
     then
         unmountGfal    #unmounts all gfal mounted directories
+        unlink /tmp/*_$(basename $PWD)
     fi         
     startLog cleanup
     info "=== ls -a ==="
@@ -31,12 +32,4 @@ function cleanup {
     date +%s
     stopLog cleanup
 }
-
-
-#exit function for any interruptions
-function exitfn () {  
-    trap -- '' SIGINT SIGTERM          #interruption is trapped
-    cleanup                            #executes cleanup function
-}
-
-trap "exitfn" INT
+export -f cleanup

--- a/src/main/resources/vm/script/basic/cleanupFunction.vm
+++ b/src/main/resources/vm/script/basic/cleanupFunction.vm
@@ -4,7 +4,10 @@
 ## $cacheDir, $cacheFile
 
 function cleanup {
-    unmountGfal          #unmount all gfal munted directories
+    if [[ $mountGfal -eq 1 ]]    #flag checks if directories are mounted with gfal
+    then
+        unmountGfal    #unmounts all gfal mounted directories
+    fi         
     startLog cleanup
     info "=== ls -a ==="
     ls -a
@@ -31,18 +34,9 @@ function cleanup {
 
 
 #exit function for any interruptions
-function exitfn () { 
-    cleanup 
-    #in case of second (or multiple) inturruptions while the 'exitfn' function being executed, 'cleanup' function is executed until 'unmountGfal' function converges to 1(true)
-    trap -- '' SIGINT SIGTERM #interruption is disabled 
-    while [[ $unmountGfal -eq 1 ]]   
-    do
-        echo $unmountGfal
-        sleep 2
-        cleanup
-    done
-    echo ABORT
-    exit                  #   then exit script.
+function exitfn () {  
+    trap -- '' SIGINT SIGTERM          #interruption is trapped
+    cleanup                            #executes cleanup function
 }
 
 trap "exitfn" INT

--- a/src/main/resources/vm/script/basic/cleanupFunction.vm
+++ b/src/main/resources/vm/script/basic/cleanupFunction.vm
@@ -4,7 +4,7 @@
 ## $cacheDir, $cacheFile
 
 function cleanup {
-
+    unmountGfal          #unmount all gfal munted directories
     startLog cleanup
     info "=== ls -a ==="
     ls -a
@@ -28,3 +28,21 @@ function cleanup {
     date +%s
     stopLog cleanup
 }
+
+
+#exit function for any interruptions
+function exitfn () { 
+    cleanup 
+    #in case of second (or multiple) inturruptions while the 'exitfn' function being executed, 'cleanup' function is executed until 'unmountGfal' function converges to 1(true)
+    trap -- '' SIGINT SIGTERM #interruption is disabled 
+    while [[ $unmountGfal -eq 1 ]]   
+    do
+        echo $unmountGfal
+        sleep 2
+        cleanup
+    done
+    echo ABORT
+    exit                  #   then exit script.
+}
+
+trap "exitfn" INT

--- a/src/main/resources/vm/script/datamanagement/downloadFunctions.vm
+++ b/src/main/resources/vm/script/datamanagement/downloadFunctions.vm
@@ -97,22 +97,29 @@ export -f downloadGirderFile
 
 #This function identifies the gfal path and extracts the basename of the directory to be mounted, and creates a directory with the exact name on $PWD of the node.
 #This directory gets mounted with the corresponding directory on the SE.
-#Only directories must be mounted using gfal (in case of mounting of a file, there will be an empty mount and it risks the failure of the application) - e.g-$SRM_HOST/home/biomed/user/....  
 
+
+check_mount='$(test -z $(for file in *; do findmnt -t fuse.gfalFS -lo Target -n -T $(realpath ${file}); done) && echo 1 || echo 0)'
+isGfalmountExec=1
 function mountGfal {
     local URI=$1
 
     # The regexpes are written so that case is ignored and the
     # arguments can be in any order.
-    local fileName=`echo $URI | sed -r 's#^srm:/(//)?([^/].*)\?.*$#\2#i'`         
-    local fileName=`echo $URI | sed -r 's#^gfal:/(//)?([^/].*)\?.*$#\2#i'`
-    local gfal_basename=$PWD/$(basename ${fileName})
-    COMMLINE1="mkdir -p $gfal_basename"
-    COMMLINE2="gfalFS -s $PWD/$(basename ${fileName}) ${fileName}"
-    ${COMMLINE1}
-    ${COMMLINE2}
-    local check_mount=$(test -z $(for file in *; do findmnt -t fuse.gfalFS -lo Target -n -T $file; done) && echo 1 || echo 0)
-    echo $check_mount
+    local fileName=`echo $URI | sed -r 's#^srm:/(//)?([^/].*)\?.*$#\2#i'`
+    local gfal_basename=$(basename ${fileName})
+    local job_id=${gfal_basename}_$(basename $PWD)
+
+    CREATE_DIR_COMMAND="mkdir -p $gfal_basename"
+    SYM_LINK_COMMAND="ln -s $PWD/$gfal_basename /tmp/$job_id"
+    GFAL_COMMAND="gfalFS -s /tmp/$job_id ${fileName}"
+
+    ${CREATE_DIR_COMMAND}
+    ${SYM_LINK_COMMAND}
+    ${GFAL_COMMAND}
+    #let nfs-kernel-server export the directory and write logs
+    sleep 10                
+    eval echo $check_mount
 }
 
 export -f mountGfal
@@ -123,25 +130,56 @@ export -f mountGfal
 
 function unmountGfal {
         START=$SECONDS
-        local i=1
-        local check_unmount=$(test -z $(for file in *; do findmnt -t fuse.gfalFS -lo Target -n -T $file; done) && echo 1 || echo 0)
-        while [ "$check_unmount" = 0 ]
+        while [ $(eval echo $check_mount) = 0 ]
         do
-                for file in $PWD/* ;do findmnt -t fuse.gfalFS -lo Target -n -T $file && gfalFS_umount $file; done
+                for file in $PWD/* ;do findmnt -t fuse.gfalFS -lo Target -n -T $(realpath ${file}) && gfalFS_umount $(realpath ${file}); done
                 sleep 2
-                check_unmount=$(test -z $(for file in *; do findmnt -t fuse.gfalFS -lo Target -n -T $file; done) && echo 1 || echo 0)
                 if [[ $SECONDS-$START -gt 600 ]] #while loops breaks in automatically after 10 mins
                 then
                     #echo "timeout"
                     break
                 fi
         done
-        echo $check_unmount
+        eval echo $check_mount
 }
 
 export -f unmountGfal
 
 
+#
+# URI are of the form of the following example.  A single "/", instead
+# of 3, after "shanoir:" is also allowed.
+# shanoir:/download.dcm?apiurl=https://shanoir-ng-nginx/shanoir-ng/datasets/carmin-data/path&format=dcm&datasetId=1
+# 
+# This method depends on refresh token process to refresh the token when it needs
+#
+function downloadShanoirFile {
+    local URI=$1
+    
+    wait_for_token
+
+    local token=`cat $SHANOIR_TOKEN_LOCATION`
+
+    echo "token inside download : ${token}"
+
+    local fileName=`echo $URI | sed -r 's#^shanoir:/(//)?([^/].*)\?.*$#\2#i'`
+    local apiUrl=`echo $URI | sed -r 's/^.*[?&]apiurl=([^&]*)(&.*)?$/\1/i'`
+    local format=`echo $URI | sed -r 's/^.*[?&]format=([^&]*)(&.*)?$/\1/i'`
+    local datasetId=`echo $URI | sed -r 's/^.*[?&]datasetId=([^&]*)(&.*)?$/\1/i'`
+
+    COMMAND(){ 
+        curl --write-out '%{http_code}' -o ${fileName} --request GET "${apiUrl}/${datasetId}?format=${format}" --header "Authorization: Bearer ${token}"
+    }
+
+    status_code=$(COMMAND)
+    echo "downloadShanoirFIle, status code is : ${status_code}"
+    
+    if [[ "$status_code" -ne 200 ]]; then
+       error "error while downloading the file with status : ${status_code}"
+       stopRefreshingToken
+       exit 1
+    fi
+}
 
 function downloadURI {
 
@@ -177,16 +215,26 @@ function downloadURI {
         validateDownload "Cannot download Girder file"
     fi
 
-    if [[ ${URI_LOWER} == gfal:/* ]] 
+    if [[ ${URI_LOWER} == shanoir:/* ]]
     then
-        mountGfal ${URI}
-        validateDownload "Cannot download gfal file"
+        if [[ "$REFRESHING_JOB_STARTED" == false ]]; then
+           #set( $D = '$' )
+           refresh_token ${URI} & 
+           REFRESH_PID=${D}!  
+           REFRESHING_JOB_STARTED=true
+        fi
+        downloadShanoirFile ${URI}
+        validateDownload "Cannot download shanoir file"
     fi
 
     if [[ ${URI_LOWER} == srm:/* ]] 
     then
-        mountGfal ${URI}
-        validateDownload "Cannot download gfal file"
+            if [[ $(mountGfal ${URI}) -eq 0 ]]
+                then
+                    isGfalmountExec=0
+                else
+                    echo "Cannot download gfal file"
+            fi
     fi
 }
 

--- a/src/main/resources/vm/script/datamanagement/downloadFunctions.vm
+++ b/src/main/resources/vm/script/datamanagement/downloadFunctions.vm
@@ -97,6 +97,7 @@ export -f downloadGirderFile
 
 #This function identifies the gfal path and extracts the basename of the directory to be mounted, and creates a directory with the exact name on $PWD of the node.
 #This directory gets mounted with the corresponding directory on the SE.
+#Only directories must be mounted using gfal (in case of mounting of a file, there will be an empty mount and it risks the failure of the application) - e.g-$SRM_HOST/home/biomed/user/....  
 
 function mountGfal {
     local URI=$1
@@ -105,7 +106,6 @@ function mountGfal {
     # arguments can be in any order.
     local fileName=`echo $URI | sed -r 's#^srm:/(//)?([^/].*)\?.*$#\2#i'`         
     local fileName=`echo $URI | sed -r 's#^gfal:/(//)?([^/].*)\?.*$#\2#i'`
-    local fileName=$(echo $URI | sed "s/gfal:\//srm:\/\/marsedpm.in2p3.fr:8446\/dpm\/in2p3.fr\/home\/biomed\/user\/c\/creatis\/vip\/data\/users\//")     #support gfal directories without mentioning full path at input/output pathsubmission (testing)
     local gfal_basename=$PWD/$(basename ${fileName})
     COMMLINE1="mkdir -p $gfal_basename"
     COMMLINE2="gfalFS -s $PWD/$(basename ${fileName}) ${fileName}"

--- a/src/main/resources/vm/script/datamanagement/downloadFunctions.vm
+++ b/src/main/resources/vm/script/datamanagement/downloadFunctions.vm
@@ -94,6 +94,50 @@ function downloadGirderFile {
 }
 export -f downloadGirderFile
 
+
+#This function identifies the gfal path and extracts the basename of the directory to be mounted, and creates a directory with the exact name on $PWD of the node.
+#This directory gets mounted with the corresponding directory on the SE.
+
+function mountGfal {
+    local URI=$1
+
+    # The regexpes are written so that case is ignored and the
+    # arguments can be in any order.
+    local fileName=`echo $URI | sed -r 's#^srm:/(//)?([^/].*)\?.*$#\2#i'`         
+    local fileName=`echo $URI | sed -r 's#^gfal:/(//)?([^/].*)\?.*$#\2#i'`
+    local fileName=$(echo $URI | sed "s/gfal:\//srm:\/\/marsedpm.in2p3.fr:8446\/dpm\/in2p3.fr\/home\/biomed\/user\/c\/creatis\/vip\/data\/users\//")     #support gfal directories without mentioning full path at input/output pathsubmission (testing)
+    local gfal_basename=$PWD/$(basename ${fileName})
+    COMMLINE1="mkdir -p $gfal_basename"
+    COMMLINE2="gfalFS -s $PWD/$(basename ${fileName}) ${fileName}"
+    ${COMMLINE1}
+    ${COMMLINE2}
+}
+
+export -f mountGfal
+
+
+
+#This function un-mounts all the gfal mounted directories by searching them with 'findmnt' and filtering them with FSTYPE 'fuse.gfalFS'
+#This function gets called in the cleanup function, either after the execution of the job, failure of the job or interruptions of the job
+
+function unmountGfal {
+        trap -- '' SIGINT SIGTERM 
+        #in case of an (or multiple) inturruption while the 'unmountgfal' function being executed, while loop is executed until 'check_unmount' converges to 1(true) before exiting the script
+        local i=1
+        local check_unmount=$(test -z $(for file in *; do findmnt -t fuse.gfalFS -lo Target -n -T $file; done) && echo 1 || echo 0)
+        while [ "$check_unmount" = 0 ]
+        do
+                for file in $PWD/* ;do findmnt -t fuse.gfalFS -lo Target -n -T $file && gfalFS_umount $file; done
+                sleep 2
+                check_unmount=$(test -z $(for file in *; do findmnt -t fuse.gfalFS -lo Target -n -T $file; done) && echo 1 || echo 0)
+        done
+        echo $check_unmount
+}
+
+export -f unmountGfal
+
+
+
 function downloadURI {
 
     local URI=$1
@@ -126,6 +170,18 @@ function downloadURI {
     then
         downloadGirderFile ${URI}
         validateDownload "Cannot download Girder file"
+    fi
+
+    if [[ ${URI_LOWER} == gfal:/* ]] 
+    then
+        mountGfal ${URI}
+        validateDownload "Cannot download gfal file"
+    fi
+
+    if [[ ${URI_LOWER} == srm:/* ]] 
+    then
+        mountGfal ${URI}
+        validateDownload "Cannot download gfal file"
     fi
 }
 

--- a/src/main/resources/vm/script/datamanagement/downloadFunctions.vm
+++ b/src/main/resources/vm/script/datamanagement/downloadFunctions.vm
@@ -111,18 +111,18 @@ function mountGfal {
     COMMLINE2="gfalFS -s $PWD/$(basename ${fileName}) ${fileName}"
     ${COMMLINE1}
     ${COMMLINE2}
+    local check_mount=$(test -z $(for file in *; do findmnt -t fuse.gfalFS -lo Target -n -T $file; done) && echo 1 || echo 0)
+    echo $check_mount
 }
 
 export -f mountGfal
-
 
 
 #This function un-mounts all the gfal mounted directories by searching them with 'findmnt' and filtering them with FSTYPE 'fuse.gfalFS'
 #This function gets called in the cleanup function, either after the execution of the job, failure of the job or interruptions of the job
 
 function unmountGfal {
-        trap -- '' SIGINT SIGTERM 
-        #in case of an (or multiple) inturruption while the 'unmountgfal' function being executed, while loop is executed until 'check_unmount' converges to 1(true) before exiting the script
+        START=$SECONDS
         local i=1
         local check_unmount=$(test -z $(for file in *; do findmnt -t fuse.gfalFS -lo Target -n -T $file; done) && echo 1 || echo 0)
         while [ "$check_unmount" = 0 ]
@@ -130,6 +130,11 @@ function unmountGfal {
                 for file in $PWD/* ;do findmnt -t fuse.gfalFS -lo Target -n -T $file && gfalFS_umount $file; done
                 sleep 2
                 check_unmount=$(test -z $(for file in *; do findmnt -t fuse.gfalFS -lo Target -n -T $file; done) && echo 1 || echo 0)
+                if [[ $SECONDS-$START -gt 600 ]] #while loops breaks in automatically after 10 mins
+                then
+                    #echo "timeout"
+                    break
+                fi
         done
         echo $check_unmount
 }


### PR DESCRIPTION
1. mounfGfal -
- This function identifies the gfal path and extracts the basename of the directory to be mounted, and creates a directory with the exact name on current directory of the node.
- This directory gets mounted with the corresponding directory on the SE.

2. unmountGfal -
- This function un-mounts all the gfal mounted directories by searching them with 'findmnt' and filtering them with FSTYPE 'fuse.gfalFS'
-  This function gets called in the cleanup function, either after the execution of the job, failure of the job or interruptions of the job.
- This function is executed in a while loop until all gfal mounted directories in $PWD are unmounted

3. downloadURI -
- This function is updated to support gfal directories with 'srm://' protocol. (also gfal://, which is under testing)

4. "exitFunction" -
- In case of interruption of the job, or failure to get the gfal directory unmounted, this function is invoked.
- It first invokes the cleanup function, and then also checks the status of unmountGal. In case inmountGfal is not executed successfully, it disables second (multiple) interruptions with (trap -- '' SIGINT SIGTERM) and runs cleanup function is loop.

5. "cleanupFunction" -
- Cleanup function is updated to call the execution of unmountGfal function.