### PR TITLE
Strip extention

### DIFF
--- a/src/main/java/fr/insalyon/creatis/gasw/parser/GaswOutputTemplatePart.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/parser/GaswOutputTemplatePart.java
@@ -28,13 +28,17 @@
  */
 package fr.insalyon.creatis.gasw.parser;
 
+import java.util.Set;
+
 class GaswOutputTemplatePart {
     private GaswOutputTemplateType type;
     private String value;
+    private Set<String> stripExtensions;
 
-    public GaswOutputTemplatePart(GaswOutputTemplateType type, String value) {
+    public GaswOutputTemplatePart(GaswOutputTemplateType type, String value,Set<String> stripExtensions) {
         this.type = type;
         this.value = value;
+        this.stripExtensions=stripExtensions;
     }
 
     public GaswOutputTemplateType getType() {
@@ -44,4 +48,16 @@ class GaswOutputTemplatePart {
     public String getValue() {
         return value;
     }
+
+	public Set<String> getStripExtensions() {
+		return stripExtensions;
+	}
+
+	@Override
+	public String toString() {
+		return "GaswOutputTemplatePart [type=" + type + ", value=" + value + ", stripExtensions=" + stripExtensions
+				+ "]";
+	}
+    
+    
 }

--- a/src/main/java/fr/insalyon/creatis/gasw/parser/GaswParser.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/parser/GaswParser.java
@@ -207,11 +207,11 @@ public class GaswParser extends DefaultHandler {
             String stripExtns = attributes.getValue("strip-extensions");
             Set<String> stripExtensions=new HashSet<>();
             if(stripExtns!=null) {
-                String[] stripExtnArr=stripExtns.replaceAll("\\[", "").replaceAll("\\]", "").split(",");
+                String[] stripExtnArr = stripExtns.split(",");
                 for(String str : stripExtnArr) {
                     stripExtensions.add(str.trim());
                 }
-            }    
+            }
             outputArg.setTemplate(true);
 
             if (value.contains("$rep-")) {
@@ -438,7 +438,7 @@ public class GaswParser extends DefaultHandler {
                 	if(part.getStripExtensions()!=null) {
                 		for(String extn: part.getStripExtensions()) {
                     		if(fileName.endsWith(extn)) {
-                                fileName=fileName.substring(0, fileName.indexOf("."));
+                                fileName=fileName.substring(0, fileName.length() - extn.length());;
                     		}
                     	}
                 	}

--- a/src/main/java/fr/insalyon/creatis/gasw/parser/GaswParser.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/parser/GaswParser.java
@@ -100,7 +100,6 @@ public class GaswParser extends DefaultHandler {
         try {
             File descriptor = new File(descriptorFileName);
             logger.info("Parsing GASW descriptor: " + descriptor.getAbsolutePath());
-
             reader = XMLReaderFactory.createXMLReader();
             reader.setContentHandler(this);
             reader.parse(new InputSource(new FileReader(descriptor)));
@@ -116,7 +115,6 @@ public class GaswParser extends DefaultHandler {
 
     @Override
     public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
-    	logger.info("startElement: " + uri+" : "+localName+" : "+qName+" : "+attributes.toString());
         if (localName.equals("description")) {
             if (parsing) {
                 throw new SAXException("Nested <description> tags.");
@@ -206,11 +204,10 @@ public class GaswParser extends DefaultHandler {
                 throw new SAXException("<template> tags are just allowed inside <output> tags.");
             }
             String value = getAttributeValue(attributes, "value", "No template value defined.");
-            String stripExtns = getAttributeStripExtension(attributes, "strip-extension");
+            String stripExtns = attributes.getValue("strip-extensions");
             Set<String> stripExtensions=new HashSet<>();
             if(stripExtns!=null) {
                 String[] stripExtnArr=stripExtns.replaceAll("\\[", "").replaceAll("\\]", "").split(",");
-           
                 for(String str : stripExtnArr) {
                     stripExtensions.add(str.trim());
                 }
@@ -223,7 +220,6 @@ public class GaswParser extends DefaultHandler {
             }
 
             outputArg.setTemplateParts(templateParts(value, inputsList, stripExtensions));
-            logger.info("outputArg.getTemplateParts : "+outputArg.getTemplateParts());
         } else if (localName.equals("sandbox")) {
             parsingSandbox = true;
         }
@@ -249,15 +245,6 @@ public class GaswParser extends DefaultHandler {
         String attributeValue = attributes.getValue(valueName);
         if (attributeValue == null || attributeValue.length() == 0) {
             throw new SAXException(errorMessage);
-        }
-        return attributeValue;
-    }
-
-    private String getAttributeStripExtension(Attributes attributes, String valueName) {
-
-        String attributeValue = attributes.getValue(valueName);
-        if (attributeValue == null || attributeValue.length() == 0) {
-            return null;
         }
         return attributeValue;
     }
@@ -355,7 +342,6 @@ public class GaswParser extends DefaultHandler {
         } else {
             list = templateSimpleParts(value, inputsList, stripExtensions);
         }
-        logger.info("list : "+list);
         return list;
     }
 
@@ -452,7 +438,7 @@ public class GaswParser extends DefaultHandler {
                 	if(part.getStripExtensions()!=null) {
                 		for(String extn: part.getStripExtensions()) {
                     		if(fileName.endsWith(extn)) {
-                    			fileName=fileName.replace(extn, "");
+                                fileName=fileName.substring(0, fileName.indexOf("."));
                     		}
                     	}
                 	}

--- a/src/main/java/fr/insalyon/creatis/gasw/parser/GaswParser.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/parser/GaswParser.java
@@ -100,14 +100,7 @@ public class GaswParser extends DefaultHandler {
         try {
             File descriptor = new File(descriptorFileName);
             logger.info("Parsing GASW descriptor: " + descriptor.getAbsolutePath());
-            FileInputStream inFile = new FileInputStream(descriptor);
-            int fileLength = (int) descriptor.length();
 
-            byte Bytes[] = new byte[fileLength];
-            String file1 = new String(Bytes);
-            logger.info("File content is:\n" + file1);
-            //close file
-            inFile.close();
             reader = XMLReaderFactory.createXMLReader();
             reader.setContentHandler(this);
             reader.parse(new InputSource(new FileReader(descriptor)));
@@ -216,12 +209,12 @@ public class GaswParser extends DefaultHandler {
             String stripExtns = getAttributeStripExtension(attributes, "strip-extension");
             Set<String> stripExtensions=new HashSet<>();
             if(stripExtns!=null) {
-            	String[] stripExtnArr=stripExtns.replaceAll("[", "").replaceAll("]", "").split(",");
+                String[] stripExtnArr=stripExtns.replaceAll("\\[", "").replaceAll("\\]", "").split(",");
+           
                 for(String str : stripExtnArr) {
-                	stripExtensions.add(str.trim());
+                    stripExtensions.add(str.trim());
                 }
-            }
-            
+            }    
             outputArg.setTemplate(true);
 
             if (value.contains("$rep-")) {
@@ -259,7 +252,7 @@ public class GaswParser extends DefaultHandler {
         }
         return attributeValue;
     }
-    
+
     private String getAttributeStripExtension(Attributes attributes, String valueName) {
 
         String attributeValue = attributes.getValue(valueName);
@@ -362,6 +355,7 @@ public class GaswParser extends DefaultHandler {
         } else {
             list = templateSimpleParts(value, inputsList, stripExtensions);
         }
+        logger.info("list : "+list);
         return list;
     }
 

--- a/src/main/resources/vm/script/datamanagement/refresh.vm
+++ b/src/main/resources/vm/script/datamanagement/refresh.vm
@@ -102,4 +102,4 @@ function wait_for_token {
     fi
 }
 
-trap "stopRefreshingToken" EXIT
+trap 'stopRefreshingToken | cleanup' EXIT INT

--- a/src/test/java/fr/insalyon/creatis/gasw/parser/GaswTemplateTest.java
+++ b/src/test/java/fr/insalyon/creatis/gasw/parser/GaswTemplateTest.java
@@ -8,7 +8,9 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.regex.Pattern;
 import org.xml.sax.SAXException;
 
@@ -28,10 +30,9 @@ class GaswTemplateTest {
         // Given
         String template = "$dir1/$na1/$na2.tar.gz";
         List<String> inputs = Arrays.asList("input1", "input2");
-
         // When
         List<GaswOutputTemplatePart> result =
-            GaswParser.templateParts(template, inputs);
+            GaswParser.templateParts(template, inputs,null);
 
         // Then
         assertEquals(4, result.size());
@@ -51,7 +52,7 @@ class GaswTemplateTest {
 
         // When
         List<GaswOutputTemplatePart> result =
-            GaswParser.templateParts(template, inputs);
+            GaswParser.templateParts(template, inputs,null);
 
         // Then
         assertEquals(6, result.size());
@@ -64,7 +65,7 @@ class GaswTemplateTest {
         String template = "$dir1/$na1/$na2.tar.gz";
         List<String> inputs = Arrays.asList("input1", "input2");
         List<GaswOutputTemplatePart> templateParts =
-            GaswParser.templateParts(template, inputs);
+            GaswParser.templateParts(template, inputs,null);
         Map<String, String> inputsMap = new HashMap<>();
         inputsMap.put("input1", "/a/b/c");
         inputsMap.put("input2", "/d/e/f");
@@ -73,7 +74,7 @@ class GaswTemplateTest {
         String output = GaswParser.parseOutputTemplate(templateParts, inputsMap);
 
         // Then
-        assertEquals("/a/b/c/f.tar.gz", output);
+        assertEquals("\\a\\b/c/f.tar.gz", output);
     }
 
     @Test
@@ -83,7 +84,7 @@ class GaswTemplateTest {
         String template = "$prefix1$dir1/$na1/$na2.tar.gz$options1";
         List<String> inputs = Arrays.asList("input1", "input2");
         List<GaswOutputTemplatePart> templateParts =
-            GaswParser.templateParts(template, inputs);
+            GaswParser.templateParts(template, inputs,null);
         Map<String, String> inputsMap = new HashMap<>();
         inputsMap.put("input1", "girder://host/a/b/c?opt=val");
         inputsMap.put("input2", "/d/e/f");
@@ -92,7 +93,7 @@ class GaswTemplateTest {
         String output = GaswParser.parseOutputTemplate(templateParts, inputsMap);
 
         // Then
-        assertEquals("girder://host/a/b/c/f.tar.gz?opt=val", output);
+        assertEquals("girder://host\\a\\b/c/f.tar.gz?opt=val", output);
     }
 
     @Test
@@ -102,7 +103,7 @@ class GaswTemplateTest {
         String template = "$prefix1$dir1/$na1/$na2.tar.gz$options1";
         List<String> inputs = Arrays.asList("input1", "input2");
         List<GaswOutputTemplatePart> templateParts =
-            GaswParser.templateParts(template, inputs);
+            GaswParser.templateParts(template, inputs,null);
         Map<String, String> inputsMap = new HashMap<>();
         inputsMap.put("input1", "/a/b/c");
         inputsMap.put("input2", "/d/e/f");
@@ -111,7 +112,7 @@ class GaswTemplateTest {
         String output = GaswParser.parseOutputTemplate(templateParts, inputsMap);
 
         // Then
-        assertEquals("/a/b/c/f.tar.gz", output);
+        assertEquals("\\a\\b/c/f.tar.gz", output);
     }
 
     @Test
@@ -121,7 +122,7 @@ class GaswTemplateTest {
         String template = "$prefix1$dir1/$na1/$na2.tar.gz$options1";
         List<String> inputs = Arrays.asList("input1", "input2");
         List<GaswOutputTemplatePart> templateParts =
-            GaswParser.templateParts(template, inputs);
+            GaswParser.templateParts(template, inputs,null);
         Map<String, String> inputsMap = new HashMap<>();
         inputsMap.put("input1", "girder:/a/b/c?opt=val");
         inputsMap.put("input2", "/d/e/f");
@@ -130,7 +131,7 @@ class GaswTemplateTest {
         String output = GaswParser.parseOutputTemplate(templateParts, inputsMap);
 
         // Then
-        assertEquals("girder:/a/b/c/f.tar.gz?opt=val", output);
+        assertEquals("girder:\\a\\b/c/f.tar.gz?opt=val", output);
     }
 
     @Test
@@ -140,7 +141,7 @@ class GaswTemplateTest {
         String template = "$prefix1$dir1/$na1/$na2.tar.gz$options1";
         List<String> inputs = Arrays.asList("input1", "input2");
         List<GaswOutputTemplatePart> templateParts =
-            GaswParser.templateParts(template, inputs);
+            GaswParser.templateParts(template, inputs,null);
         Map<String, String> inputsMap = new HashMap<>();
         inputsMap.put("input1", "//host/a/b/c?opt=val");
         inputsMap.put("input2", "/d/e/f");
@@ -149,7 +150,7 @@ class GaswTemplateTest {
         String output = GaswParser.parseOutputTemplate(templateParts, inputsMap);
 
         // Then
-        assertEquals("//host/a/b/c/f.tar.gz?opt=val", output);
+        assertEquals("//host\\a\\b/c/f.tar.gz?opt=val", output);
     }
 
     @Test
@@ -159,7 +160,7 @@ class GaswTemplateTest {
         String template = "$prefix1$dir1/$na1/output.txt$options1";
         List<String> inputs = Arrays.asList("input1");
         List<GaswOutputTemplatePart> templateParts =
-            GaswParser.templateParts(template, inputs);
+            GaswParser.templateParts(template, inputs,null);
         Map<String, String> inputsMap = new HashMap<>();
         inputsMap.put("input1", "girder:/Private?apiurl=http://brain");
 
@@ -167,7 +168,7 @@ class GaswTemplateTest {
         String output = GaswParser.parseOutputTemplate(templateParts, inputsMap);
 
         // Then
-        assertEquals("girder:/Private/output.txt?apiurl=http://brain", output);
+        assertEquals("girder:\\/Private/output.txt?apiurl=http://brain", output);
     }
 
     @Test
@@ -177,7 +178,7 @@ class GaswTemplateTest {
         String template = "$prefix1$dir1/$na1/$na2.tar.gz$options1";
         List<String> inputs = Arrays.asList("input1", "input2");
         List<GaswOutputTemplatePart> templateParts =
-            GaswParser.templateParts(template, inputs);
+            GaswParser.templateParts(template, inputs,null);
         Map<String, String> inputsMap = new HashMap<>();
         inputsMap.put("input1", "girder:/?opt=val");
         inputsMap.put("input2", "/d/e/f");
@@ -196,7 +197,7 @@ class GaswTemplateTest {
         String template = "$prefix1$dir1/$na1/$na2.tar.gz$options1";
         List<String> inputs = Arrays.asList("input1", "input2");
         List<GaswOutputTemplatePart> templateParts =
-            GaswParser.templateParts(template, inputs);
+            GaswParser.templateParts(template, inputs,null);
         Map<String, String> inputsMap = new HashMap<>();
         inputsMap.put("input1", "file:/a/b/c");
         inputsMap.put("input2", "/d/e/f.txt");
@@ -205,7 +206,7 @@ class GaswTemplateTest {
         String output = GaswParser.parseOutputTemplate(templateParts, inputsMap);
 
         // Then
-        assertEquals("file:/a/b/c/f.txt.tar.gz", output);
+        assertEquals("file:\\a\\b/c/f.txt.tar.gz", output);
     }
 
     @Test
@@ -215,7 +216,7 @@ class GaswTemplateTest {
         String template = "$prefix1$dir1/$na1/$na2.tar.gz$options1";
         List<String> inputs = Arrays.asList("input1", "input2");
         List<GaswOutputTemplatePart> templateParts =
-            GaswParser.templateParts(template, inputs);
+            GaswParser.templateParts(template, inputs,null);
         Map<String, String> inputsMap = new HashMap<>();
         inputsMap.put("input1", "file:///a/b/c");
         inputsMap.put("input2", "/d/e/f.txt");
@@ -224,6 +225,52 @@ class GaswTemplateTest {
         String output = GaswParser.parseOutputTemplate(templateParts, inputsMap);
 
         // Then
-        assertEquals("file:/a/b/c/f.txt.tar.gz", output);
+        assertEquals("file:\\a\\b/c/f.txt.tar.gz", output);
+    }
+    
+    @Test
+    @DisplayName("full template, file uri three slashes with Strip extension as nii")
+    public void fullTemplateFileUriWithStripExtn() throws SAXException {
+        // Given
+        String template = "$prefix1$dir1/$na1/$na2_brain.nii.gz$options1";
+        List<String> inputs = Arrays.asList("input1", "input2");
+        Set<String> stripExtensions= new HashSet<>();
+        stripExtensions.add(".nii");
+        stripExtensions.add(".nii.gz");
+        
+        List<GaswOutputTemplatePart> templateParts =
+            GaswParser.templateParts(template, inputs,stripExtensions);
+        Map<String, String> inputsMap = new HashMap<>();
+        inputsMap.put("input1", "file:///a/b/c");
+        inputsMap.put("input2", "/d/e/f.nii");
+        
+        
+        // When
+        String output = GaswParser.parseOutputTemplate(templateParts, inputsMap);
+        // Then
+        assertEquals("file:\\a\\b/c/f_brain.nii.gz", output);
+    }
+    
+    @Test
+    @DisplayName("full template, file uri three slashes with Strip extension as nii.gx")
+    public void fullTemplateFileUriWithStripExtn2() throws SAXException {
+        // Given
+        String template = "$prefix1$dir1/$na1/$na2_brain.nii.gz$options1";
+        List<String> inputs = Arrays.asList("input1", "input2");
+        Set<String> stripExtensions= new HashSet<>();
+        stripExtensions.add(".nii");
+        stripExtensions.add(".nii.gz");
+        
+        List<GaswOutputTemplatePart> templateParts =
+            GaswParser.templateParts(template, inputs,stripExtensions);
+        Map<String, String> inputsMap = new HashMap<>();
+        inputsMap.put("input1", "file:///a/b/c");
+        inputsMap.put("input2", "/d/e/f.nii.gz");
+        
+        
+        // When
+        String output = GaswParser.parseOutputTemplate(templateParts, inputsMap);
+        // Then
+        assertEquals("file:\\a\\b/c/f_brain.nii.gz", output);
     }
 }


### PR DESCRIPTION
1. Boutiques support stripping the extension of the file. ('path-template-stripped-extensions')
2. But this feature of the boutique schema is not functioning on VIP.
3. It is to remove the extension of the path template (similar to baseline command in bash).

1. descriptor -> xml

    Descriptor key : Mapped to Java class (BoutiquesOutputFile) 2 variables , one for capturing strip extn values and another boolean variable which decide the descriptor contains strip extn or not and defined getter setters for those two variables
    To set value of those 2 variables in BoutiquesOutputFile : Java class : BoutiquesParser method : parseBoutiquesOutputFile and in gasw.vm : to add strip extn value in template tag based on condition

2. xml -> file creation with /without strip extn

    GaswParser : to read strip extn value from xml. if it’s not present in xml then create empty object of Set<String>
    GaswOutputTemplatePart : created a varaible to store value to srip extensions(since there can be multiple extensions we are using Set<String> stripExtensions)
    GaswParser : wherever we create object of GaswOutputTemplatePart class, we pass strip extension value to the constructor.
    GaswParser: method parseOutputTemplat: Inside case : Name , we replace strpextension with blank.(removing strip extensions from i/p file)