### PR TITLE
Gfal_support

### DIFF
--- a/src/main/resources/vm/script/basic/cleanupFunction.vm
+++ b/src/main/resources/vm/script/basic/cleanupFunction.vm
@@ -31,6 +31,8 @@ function cleanup {
     info "END date:"
     date +%s
     stopLog cleanup
+    check_cleanup = true
 }
 
 export -f cleanup
+trap 'if [ "$check_cleanup" = true ]; then echo "cleanup was executed successfully"; else cleanup && echo "Executing cleanup"; fi' INT

--- a/src/main/resources/vm/script/basic/cleanupFunction.vm
+++ b/src/main/resources/vm/script/basic/cleanupFunction.vm
@@ -35,4 +35,4 @@ function cleanup {
 }
 
 export -f cleanup
-trap 'if [ "$check_cleanup" = true ]; then echo "cleanup was executed successfully"; else cleanup && echo "Executing cleanup"; fi' INT
+trap 'echo "trap activation" && stopRefreshingToken | if [ "$check_cleanup" = true ]; then echo "cleanup was executed successfully"; else echo "Executing cleanup" && cleanup; fi' INT EXIT

--- a/src/main/resources/vm/script/basic/cleanupFunction.vm
+++ b/src/main/resources/vm/script/basic/cleanupFunction.vm
@@ -4,7 +4,11 @@
 ## $cacheDir, $cacheFile
 
 function cleanup {
-
+    if [[ $isGfalmountExec -eq 0 ]]    #flag checks if directories are mounted with gfal
+    then
+        unmountGfal    #unmounts all gfal mounted directories
+        unlink /tmp/*_$(basename $PWD)
+    fi         
     startLog cleanup
     info "=== ls -a ==="
     ls -a
@@ -28,3 +32,5 @@ function cleanup {
     date +%s
     stopLog cleanup
 }
+
+export -f cleanup

--- a/src/main/resources/vm/script/datamanagement/downloadFunctions.vm
+++ b/src/main/resources/vm/script/datamanagement/downloadFunctions.vm
@@ -136,7 +136,7 @@ function unmountGfal {
                 sleep 2
                 if [[ $SECONDS-$START -gt 600 ]] #while loops breaks in automatically after 10 mins
                 then
-                    #echo "WARNING -gfal directory couldn't be unmounted:timeout"
+                    echo "WARNING -gfal directory couldn't be unmounted:timeout"
                     break
                 fi
         done

--- a/src/main/resources/vm/script/datamanagement/downloadFunctions.vm
+++ b/src/main/resources/vm/script/datamanagement/downloadFunctions.vm
@@ -94,6 +94,58 @@ function downloadGirderFile {
 }
 export -f downloadGirderFile
 
+
+#This function identifies the gfal path and extracts the basename of the directory to be mounted, and creates a directory with the exact name on $PWD of the node.
+#This directory gets mounted with the corresponding directory on the SE.
+
+#check_mount checks for all the gfal mounts in the current folder
+check_mount='$(test -z $(for file in *; do findmnt -t fuse.gfalFS -lo Target -n -T $(realpath ${file}); done) && echo 1 || echo 0)'
+isGfalmountExec=1
+function mountGfal {
+    local URI=$1
+
+    # The regexpes are written so that case is ignored and the
+    # arguments can be in any order.
+    local fileName=`echo $URI | sed -r 's#^srm:/(//)?([^/].*)\?.*$#\2#i'`
+    local gfal_basename=$(basename ${fileName})
+    local job_id=${gfal_basename}_$(basename $PWD)
+
+    CREATE_DIR_COMMAND="mkdir -p $gfal_basename"
+    SYM_LINK_COMMAND="ln -s $PWD/$gfal_basename /tmp/$job_id"
+    GFAL_COMMAND="gfalFS -s /tmp/$job_id ${fileName}"
+
+    ${CREATE_DIR_COMMAND}
+    ${SYM_LINK_COMMAND}
+    ${GFAL_COMMAND}
+    #let nfs-kernel-server export the directory and write logs
+    sleep 10                
+    eval echo $check_mount
+}
+
+export -f mountGfal
+
+
+#This function un-mounts all the gfal mounted directories by searching them with 'findmnt' and filtering them with FSTYPE 'fuse.gfalFS'
+#This function gets called in the cleanup function, either after the execution of the job, failure of the job or interruptions of the job
+
+function unmountGfal {
+        START=$SECONDS
+        while [ $(eval echo $check_mount) = 0 ]
+        do
+                for file in $PWD/* ;do findmnt -t fuse.gfalFS -lo Target -n -T $(realpath ${file}) && gfalFS_umount $(realpath ${file}); done
+                sleep 2
+                if [[ $SECONDS-$START -gt 600 ]] #while loops breaks in automatically after 10 mins
+                then
+                    #echo "WARNING -gfal directory couldn't be unmounted:timeout"
+                    break
+                fi
+        done
+        eval echo $check_mount
+}
+
+export -f unmountGfal
+
+
 #
 # URI are of the form of the following example.  A single "/", instead
 # of 3, after "shanoir:" is also allowed.
@@ -174,6 +226,16 @@ function downloadURI {
         downloadShanoirFile ${URI}
         validateDownload "Cannot download shanoir file"
     fi
+
+    if [[ ${URI_LOWER} == srm:/* ]] 
+    then
+            if [[ $(mountGfal ${URI}) -eq 0 ]]
+                then
+                    isGfalmountExec=0
+                else
+                    echo "Cannot download gfal file"
+            fi
+    fi
 }
 
 function validateDownload() {
@@ -185,4 +247,3 @@ function validateDownload() {
         exit 1
     fi
 }
-

--- a/src/main/resources/vm/script/datamanagement/refresh.vm
+++ b/src/main/resources/vm/script/datamanagement/refresh.vm
@@ -102,4 +102,4 @@ function wait_for_token {
     fi
 }
 
-trap "stopRefreshingToken" EXIT
+trap 'stopRefreshingToken | cleanup' EXIT INT 

--- a/src/main/resources/vm/script/datamanagement/refresh.vm
+++ b/src/main/resources/vm/script/datamanagement/refresh.vm
@@ -101,5 +101,3 @@ function wait_for_token {
         exit 1
     fi
 }
-
-trap "stopRefreshingToken" EXIT

--- a/src/main/resources/vm/script/datamanagement/refresh.vm
+++ b/src/main/resources/vm/script/datamanagement/refresh.vm
@@ -102,4 +102,4 @@ function wait_for_token {
     fi
 }
 
-trap 'stopRefreshingToken | cleanup' EXIT INT
+trap "stopRefreshingToken" EXIT

--- a/src/main/resources/vm/script/datamanagement/refresh.vm
+++ b/src/main/resources/vm/script/datamanagement/refresh.vm
@@ -102,4 +102,4 @@ function wait_for_token {
     fi
 }
 
-trap 'stopRefreshingToken | cleanup' EXIT INT 
+trap 'stopRefreshingToken | cleanup' EXIT INT


### PR DESCRIPTION


**mounfGfal** -

    This function identifies the gfal path and extracts the basename of the directory to be mounted, and creates a directory with the exact name on current directory of the node.
    This directory gets mounted with the corresponding directory on the SE.

**unmountGfal** -

    This function un-mounts all the gfal mounted directories by searching them with 'findmnt' and filtering them with FSTYPE 'fuse.gfalFS'
    This function gets called in the cleanup function, either after the execution of the job, failure of the job or interruptions of the job.
    This function is executed in a while loop until all gfal mounted directories in $PWD are unmounted

**downloadURI** -

    This function is updated to support gfal directories with 'srm://' protocol. (also gfal://, which is under testing)

"**trap**" -

    In case of interruption of the job, or failure to get the gfal directory unmounted, this function is invoked.
    It first invokes the cleanup function, and then also checks the status of unmountGal. In case unmountGfal is not executed successfully, it runs cleanup function is loop.

"**cleanupFunction**" -

    Cleanup function is updated to call the execution of unmountGfal function, and check flag

