### PR TITLE
mountGfal function - increament in sleep time

### DIFF
--- a/src/main/resources/vm/script/datamanagement/downloadFunctions.vm
+++ b/src/main/resources/vm/script/datamanagement/downloadFunctions.vm
@@ -118,7 +118,7 @@ function mountGfal {
     ${SYM_LINK_COMMAND}
     ${GFAL_COMMAND}
     #let nfs-kernel-server export the directory and write logs
-    sleep 10                
+    sleep 30                
     eval echo $check_mount
 }
 


### PR DESCRIPTION
increment in sleep time in mountGfal function to 30 seconds to avoid error -Device or resource busy  (nfs-kernel)