### PR TITLE
Add singularityPath

### DIFF
--- a/src/main/java/fr/insalyon/creatis/gasw/GaswConfiguration.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/GaswConfiguration.java
@@ -96,7 +96,7 @@ public class GaswConfiguration {
     private String voUseCloseSE;
     // Boutiques installation
     private String boshCVMFSPath;
-    private String apptainerPath;
+    private String singularityPath;
     private String containersCVMFSPath;
     private String udockerTag;
     private String boutiquesProvenanceDir;
@@ -171,7 +171,7 @@ public class GaswConfiguration {
             voUseCloseSE = config.getString(GaswConstants.LAB_VO_USE_CLOSE_SE, "\"true\"");
 
             boshCVMFSPath = config.getString(GaswConstants.LAB_BOSH_CVMFS_PATH, "\"/cvmfs/biomed.egi.eu/vip/virtualenv/bin\"");
-            apptainerPath = config.getString(GaswConstants.LAB_APPTAINER_PATH, "\"/cvmfs/dirac.egi.eu/container/apptainer/bin\"");
+            singularityPath = config.getString(GaswConstants.LAB_SINGULARITY_PATH, "\"/cvmfs/dirac.egi.eu/dirac/v8.0.39/Linux-x86_64/bin\"");
             containersCVMFSPath = config.getString(GaswConstants.LAB_CONTAINERS_CVMFS_PATH, "\"/cvmfs/biomed.egi.eu/vip/udocker/containers\"");
             udockerTag = config.getString(GaswConstants.LAB_UDOCKER_TAG, "\"1.3.1\"");
             boutiquesProvenanceDir = config.getString(GaswConstants.LAB_BOUTIQUES_PROV_DIR, "\"$HOME/.cache/boutiques/data\"");
@@ -206,7 +206,7 @@ public class GaswConfiguration {
             config.setProperty(GaswConstants.LAB_VO_USE_CLOSE_SE, voUseCloseSE);
             
 	        config.setProperty(GaswConstants.LAB_BOSH_CVMFS_PATH, boshCVMFSPath);
-            config.setProperty(GaswConstants.LAB_APPTAINER_PATH, apptainerPath);
+            config.setProperty(GaswConstants.LAB_SINGULARITY_PATH, singularityPath);
             config.setProperty(GaswConstants.LAB_CONTAINERS_CVMFS_PATH, containersCVMFSPath);
             config.setProperty(GaswConstants.LAB_UDOCKER_TAG, udockerTag);
             config.setProperty(GaswConstants.LAB_BOUTIQUES_PROV_DIR, boutiquesProvenanceDir);
@@ -442,16 +442,16 @@ public class GaswConfiguration {
         return boshCVMFSPath;
     }
 
-    public String getApptainerPath() {
-        return apptainerPath;
-    }
-
     public String getBoutiquesProvenanceDir() {
         return boutiquesProvenanceDir;
     }
 
     public String getBoutiquesFilename() {
         return boutiquesFileName;
+    }
+
+    public String getSingularityPath() {
+        return singularityPath;
     }
 
     public String getContainersCVMFSPath() {

--- a/src/main/java/fr/insalyon/creatis/gasw/GaswConstants.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/GaswConstants.java
@@ -60,7 +60,7 @@ public class GaswConstants {
     public static final String LAB_VO_NAME = "vo.name";
     public static final String LAB_VO_USE_CLOSE_SE = "vo.use.close.se";
     public static final String LAB_BOSH_CVMFS_PATH = "bosh.cvmfs.path";
-    public static final String LAB_APPTAINER_PATH = "apptainer.path";
+    public static final String LAB_SINGULARITY_PATH = "singularity.path";
     public static final String LAB_CONTAINERS_CVMFS_PATH = "containers.cvmfs.path";
     public static final String LAB_UDOCKER_TAG = "udocker.tag";
     public static final String LAB_BOUTIQUES_PROV_DIR = "boutiques.provenance.dir";

--- a/src/main/java/fr/insalyon/creatis/gasw/script/ExecutionGenerator.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/script/ExecutionGenerator.java
@@ -81,6 +81,7 @@ public class ExecutionGenerator {
         velocity.put("voUseCloseSE", conf.getVoUseCloseSE());
         velocity.put("boshCVMFSPath", conf.getBoshCVMFSPath());
         velocity.put("boutiquesProvenanceDir", conf.getBoutiquesProvenanceDir());
+        velocity.put("singularityPath", conf.getSingularityPath());
         velocity.put("containersCVMFSPath", conf.getContainersCVMFSPath());
         velocity.put("udockerTag", conf.getUdockerTag());
         velocity.put("simulationID", conf.getSimulationID());

--- a/src/main/java/fr/insalyon/creatis/gasw/script/MoteurliteConfigGenerator.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/script/MoteurliteConfigGenerator.java
@@ -85,6 +85,7 @@ import fr.insalyon.creatis.gasw.execution.GaswMinorStatusServiceGenerator;
              config.put("voUseCloseSE", conf.getVoUseCloseSE());
              config.put("boshCVMFSPath", conf.getBoshCVMFSPath());
              config.put("boutiquesProvenanceDir", conf.getBoutiquesProvenanceDir());
+             config.put("singularityPath", conf.getSingularityPath());
              config.put("containersCVMFSPath", conf.getContainersCVMFSPath());
              config.put("udockerTag", conf.getUdockerTag());
              config.put("simulationID", conf.getSimulationID());

--- a/src/main/resources/script.sh
+++ b/src/main/resources/script.sh
@@ -1061,6 +1061,8 @@ then
     download_udocker
 fi
 # Check that singularity is in PATH
+# command -v displays the path to singularity if found
+info "checking for singularity"
 if ! command -v singularity
 then
     if test -d "$singularityPath"; then

--- a/src/main/resources/script.sh
+++ b/src/main/resources/script.sh
@@ -1060,6 +1060,16 @@ if ! command -v docker
 then
     download_udocker
 fi
+# Check that singularity is in PATH
+if ! command -v singularity
+then
+    if test -d "$singularityPath"; then
+        export PATH="$singularityPath:$PATH"
+        info "adding singularityPath to PATH ($singularityPath)"
+    else
+        warning "singularityPath not found ($singularityPath), leaving PATH unchanged"
+    fi
+fi
 ####################################################################################################
 
 # Export current directory to LD_LIBRARY_PATH


### PR DESCRIPTION
This pull request replaces #83 and #84 :
- It introduces a new "singularity.path" setting in GASW config, replacing the existing "apptainer.path", which didn't work anyways.
- This setting is then exposed as `$singularityPath` in the execution script (`script.sh` in present PR, and `wrapper.vm` in related VIP-portal PR), and used to adjust PATH at runtime in case the `singularity` command is not found on the execution node.
