### PR TITLE
Fix GaswParser with URI + stripExtensions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>fr.insalyon.creatis</groupId>
     <artifactId>gasw</artifactId>
     <packaging>jar</packaging>
-    <version>3.11.1</version>
+    <version>3.11.2</version>
     <name>GASW</name>
 
     <properties>

--- a/src/main/java/fr/insalyon/creatis/gasw/parser/GaswParser.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/parser/GaswParser.java
@@ -427,7 +427,7 @@ public class GaswParser extends DefaultHandler {
                 case DIR_AND_NAME:
                 {
                     addDir(inputsMap.get(part.getValue()), content);
-                    addName("/", inputsMap.get(part.getValue()), content);
+                    addName("/", inputsMap.get(part.getValue()), content, null);
                 }
                 break;
                 case DIR:
@@ -437,17 +437,7 @@ public class GaswParser extends DefaultHandler {
                 break;
                 case NAME:
                 {
-                    URI u = new URI(inputsMap.get(part.getValue()));
-                    File f = new File(u.getPath());
-                    String basename = f.getName();
-                	if (part.getStripExtensions()!=null) {
-                		for (String extn : part.getStripExtensions()) {
-                            if (basename.endsWith(extn)) {
-                                basename = basename.substring(0, basename.length() - extn.length());
-                    		}
-                    	}
-                	}
-                    content.append(basename);
+                    addName("", inputsMap.get(part.getValue()), content, part.getStripExtensions());
                 }
                 break;
                 case OPTIONS:
@@ -483,13 +473,20 @@ public class GaswParser extends DefaultHandler {
     }
 
     private static void addName(
-        String separator, String s, StringBuilder content)
+        String separator, String uri, StringBuilder content, Set<String> strippedExtensions)
         throws URISyntaxException {
 
-        URI u = new URI(s);
-        File f = new File(u.getPath());
-        if (f.getName().length() > 0) {
-            content.append(separator).append(f.getName());
+        URI u = new URI(uri);
+        String filename = new File(u.getPath()).getName();
+        if (strippedExtensions != null) {
+            for (String extn : strippedExtensions) {
+                if (filename.endsWith(extn)) {
+                    filename = filename.substring(0, filename.length() - extn.length());;
+                }
+            }
+        }
+        if (filename.length() > 0) {
+            content.append(separator).append(filename);
         }
     }
 }

--- a/src/main/java/fr/insalyon/creatis/gasw/parser/GaswParser.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/parser/GaswParser.java
@@ -437,15 +437,17 @@ public class GaswParser extends DefaultHandler {
                 break;
                 case NAME:
                 {
-                	String inputValue = inputsMap.get(part.getValue());
+                    URI u = new URI(inputsMap.get(part.getValue()));
+                    File f = new File(u.getPath());
+                    String basename = f.getName();
                 	if (part.getStripExtensions()!=null) {
                 		for (String extn : part.getStripExtensions()) {
-                    		if (inputValue.endsWith(extn)) {
-                                inputValue=inputValue.substring(0, inputValue.length() - extn.length());;
+                            if (basename.endsWith(extn)) {
+                                basename = basename.substring(0, basename.length() - extn.length());
                     		}
                     	}
                 	}
-                    addName("", inputValue, content);
+                    content.append(basename);
                 }
                 break;
                 case OPTIONS:

--- a/src/test/java/fr/insalyon/creatis/gasw/parser/GaswTemplateTest.java
+++ b/src/test/java/fr/insalyon/creatis/gasw/parser/GaswTemplateTest.java
@@ -299,4 +299,26 @@ class GaswTemplateTest {
         // Then
         assertEquals("file:/a/b/c/f_brain.out", output);
     }
+
+    @Test
+    @DisplayName("full template, Girder URI with strip extension")
+    public void fullTemplateGirderUriWithStripExtn() throws SAXException {
+        // Given
+        String template = "$prefix1$dir1/$na1/$na2.out$options1";
+        List<String> inputs = Arrays.asList("input1", "input2");
+        Set<String> stripExtensions= new HashSet<>();
+        stripExtensions.add(".nii");
+
+        List<GaswOutputTemplatePart> templateParts =
+                GaswParser.templateParts(template, inputs, stripExtensions);
+        Map<String, String> inputsMap = new HashMap<>();
+        // actual Girder query strings are of the form ?apiurl=https://host/main/api/v1&fileId=...&token=...
+        inputsMap.put("input1", "girder:/outputdir/results?fileId=5678");
+        inputsMap.put("input2", "girder:/inputdir/file.nii?fileId=1234");
+
+        // When
+        String output = GaswParser.parseOutputTemplate(templateParts, inputsMap);
+        // Then
+        assertEquals("girder:/outputdir/results/file.out?fileId=5678", output);
+    }
 }


### PR DESCRIPTION
This is a hotfix for `GASW:master` which shoud also be applied to `develop` :
- Extensions stripping in output filename was not done when the input name contained a query string, for instance on Girder
- Add a related unit test
- Fix indentation

Note : if there are several extensions, I also wondered whether we should stop after the first matching extension, instead of stripping all matching extensions as we currently do. If we look at boutiques for the reference behaviour, then stripping all matching extensions is indeed the correct behaviour, cf https://github.com/boutiques/boutiques/blob/master/boutiques/localExec.py#L1222 :
```
                    for extension in stripped_extensions:
                        val = val.replace(extension, "")
```