### PR TITLE
Add --stream flag to bosh exec launch

### DIFF
--- a/src/main/resources/script.sh
+++ b/src/main/resources/script.sh
@@ -715,7 +715,7 @@ function performExec {
   mkdir -p "$tmpfolder"
 
   # Extract imagepath
-  local boshopts=()
+  local boshopts=("--stream")
   local imagepath=$(python -c 'import sys,json;v=json.load(sys.stdin).get("custom",None);print(v.get("vip:imagepath","") if isinstance(v,dict) else "")' < "../$boutiquesFilename")
   if [ -n "$imagepath" ]; then
     boshopts+=("--imagepath" "$imagepath")


### PR DESCRIPTION
As for https://github.com/virtual-imaging-platform/VIP-portal/pull/521, this patch adds the `--stream` flag to bosh exec launch, here for Moteurlite executions.
Contrary to this other PR, the present change is effective immediately on all apps, as it's directly in script.sh.

