### PR TITLE
Remove "time" usage in script.sh

### DIFF
--- a/src/main/resources/script.sh
+++ b/src/main/resources/script.sh
@@ -444,14 +444,15 @@ function downloadLFN {
 
   local totalTimeout=$((timeout + srmTimeout + sendReceiveTimeout))
 
-  local LINE="time -p dirac-dms-get-file -d -o /Resources/StorageElements/GFAL_TIMEOUT=${totalTimeout} ${LFN}"
+  local LINE="dirac-dms-get-file -d -o /Resources/StorageElements/GFAL_TIMEOUT=${totalTimeout} ${LFN}"
   info "$LINE"
+  local startDownload=$(date +%s)
   (${LINE}) &> get-file.log
 
   if [ $? = 0 ]; then
+    local duration=$(($(date +%s) - startDownload))
     info "dirac-dms-get-file worked fine"
     local source=$(grep "generating url" get-file.log | tail -1 | sed -r 's/^.* (.*)\.$/\1/')
-    local duration=$(grep -P '^real[ \t]' get-file.log | sed -r 's/real[ \t]//')
     info "DownloadCommand=dirac-dms-get-file Source=${source} Destination=$(hostname) Size=${size} Time=${duration}"
     RET_VAL=0
   else
@@ -820,11 +821,13 @@ function uploadLfnFile {
       local command="dirac-dms-add-file"
       local source=$(hostname)
       dirac-dms-remove-files "$OPTS" "$LFN" &>/dev/null
-      (time -p dirac-dms-add-file "$OPTS" "$LFN" "$FILE" "$DEST") &> dirac.log
+      local startUpload=$(date +%s)
+      (dirac-dms-add-file "$OPTS" "$LFN" "$FILE" "$DEST") &> dirac.log
       local error_code=$?
     else
       local command="dirac-dms-replicate-lfn"
-      (time -p dirac-dms-replicate-lfn -d "$OPTS" "$LFN" "$DEST") &> dirac.log
+      local startUpload=$(date +%s)
+      (dirac-dms-replicate-lfn -d "$OPTS" "$LFN" "$DEST") &> dirac.log
       local error_code=$?
 
       local source=$(grep "operation 'getFileSize'" dirac.log | tail -1 | sed -r 's/^.* StorageElement (.*) is .*$/\1/')
@@ -832,7 +835,7 @@ function uploadLfnFile {
     if [ ${error_code} = 0 ]; then
       info "Copy/Replication of ${LFN} to SE ${DEST} worked fine."
       done=$((done + 1))
-      local duration=$(grep -P '^real[ \t]' dirac.log | sed -r 's/real[ \t]//')
+      local duration=$(($(date +%s) - startUpload))
       info "UploadCommand=${command} Source=${source} Destination=${DEST} Size=${size} Time=${duration}"
       if [ -z "${duration}" ]; then
         info "Missing duration info, printing the whole log file."

--- a/src/main/resources/script.sh
+++ b/src/main/resources/script.sh
@@ -831,16 +831,16 @@ function uploadLfnFile {
     fi
     if [ ${error_code} = 0 ]; then
       info "Copy/Replication of ${LFN} to SE ${DEST} worked fine."
-    done=$((done + 1))
-    local duration=$(grep -P '^real[ \t]' dirac.log | sed -r 's/real[ \t]//')
-    info "UploadCommand=${command} Source=${source} Destination=${DEST} Size=${size} Time=${duration}"
-    if [ -z "${duration}" ]; then
-      info "Missing duration info, printing the whole log file."
-      cat dirac.log
-    fi
-  else
-    error "$(cat dirac.log)"
-    warning "Copy/Replication of ${LFN} to SE ${DEST} failed"
+      done=$((done + 1))
+      local duration=$(grep -P '^real[ \t]' dirac.log | sed -r 's/real[ \t]//')
+      info "UploadCommand=${command} Source=${source} Destination=${DEST} Size=${size} Time=${duration}"
+      if [ -z "${duration}" ]; then
+        info "Missing duration info, printing the whole log file."
+        cat dirac.log
+      fi
+    else
+      error "$(cat dirac.log)"
+      warning "Copy/Replication of ${LFN} to SE ${DEST} failed"
     fi
     rm dirac.log
     chooseRandomSE


### PR DESCRIPTION
- Commit https://github.com/virtual-imaging-platform/GASW/commit/993741a35a9b558c90cb57982b63809d26abb611 is just an indentation fix
- Commit https://github.com/virtual-imaging-platform/GASW/commit/33940a797091c4d75666263fedf44beb67043e66 contains the actual patch : it removes the `time -p` call and related logfile parsing in LFN download/upload, in favor of just a subtraction between two `date +%s` commands.

This is meant to improve compatibility with runtime environments without `time` : `date +%s` was already used elsewhere in `script.sh`, so no new dependency is added. One minor downside is that the number format for the duration log line changes from a 2-digits float to an integer, and we slightly lose in precision (from 0.01s in previous implementation to 1-2s now). If needed, sub-second precision would be doable with `date +%s.%N`, and we'd need a call to `python` for the subtraction as shells don't do floating point arithmetic.
