### PR TITLE
Fix per-job provenance file matching, cleanup boutiques cache

### DIFF
--- a/src/main/resources/script.sh
+++ b/src/main/resources/script.sh
@@ -1000,10 +1000,18 @@ function copyProvenanceFile {
     error "No provenance found in boutiques cache $boutiquesProvenanceDir"
     return 2
   fi
+  # found a provenance file for our job, get the related archived descriptor
   info "Found provenance file $boutiquesProvenanceDir/$provenanceFile"
-  info "Copying it to $dest"
+  local descriptorFile=$(getJsonDepth2 "$boutiquesProvenanceDir/$provenanceFile" "summary" "descriptor-doi")
+  # move the provenance file from boutiques cache
+  info "Moving it to $dest"
   cp "$boutiquesProvenanceDir/$provenanceFile" "$BASEDIR"
-  cp "$boutiquesProvenanceDir/$provenanceFile" "$dest"
+  mv "$boutiquesProvenanceDir/$provenanceFile" "$dest"
+  # also cleanup the archived descriptor, to avoid accumulation over time
+  if [ -e "$boutiquesProvenanceDir/$descriptorFile" ]; then
+    info "Cleaning up descriptor cache $descriptorFile"
+    rm -f "$boutiquesProvenanceDir/$descriptorFile"
+  fi
 }
 
 # performUpload: handle top-level upload step

--- a/src/main/resources/script.sh
+++ b/src/main/resources/script.sh
@@ -93,6 +93,15 @@ function showHostConfig {
   stopLog host_config
 }
 
+# getJsonDepth2: get the value of key1.key2 from a json file.
+# Print output on stdout, blank when not found.
+function getJsonDepth2 {
+  local file="$1"
+  local key1="$2"
+  local key2="$3"
+  python -c 'import sys,json;v=json.load(sys.stdin).get("'"$key1"'",None);print(v.get("'"$key2"'","") if isinstance(v,dict) else "")' < "$file"
+}
+
 ## runtime tools installation
 
 # checkBosh: install bosh if needed, or make it available in PATH
@@ -704,7 +713,7 @@ function performExec {
 
   # Get execution tools
   checkBosh
-  local containerType=$(python -c 'import sys,json;v=json.load(sys.stdin).get("container-image",None);print(v.get("type","") if isinstance(v,dict) else "")' < "../$boutiquesFilename")
+  local containerType=$(getJsonDepth2 "../$boutiquesFilename" "container-image" "type")
   case "$containerType" in
     docker) checkDocker ;;
     singularity) checkSingularity ;;
@@ -716,7 +725,7 @@ function performExec {
 
   # Extract imagepath
   local boshopts=("--stream")
-  local imagepath=$(python -c 'import sys,json;v=json.load(sys.stdin).get("custom",None);print(v.get("vip:imagepath","") if isinstance(v,dict) else "")' < "../$boutiquesFilename")
+  local imagepath=$(getJsonDepth2 "../$boutiquesFilename" "custom" "vip:imagepath")
   if [ -n "$imagepath" ]; then
     boshopts+=("--imagepath" "$imagepath")
   fi


### PR DESCRIPTION
This patch fixes provenance file matching, to ensure that a job always uses the file produced by its own `bosh exec` call. Before, the most recent file was used after bosh termination, leading to a race condition and possible mangling of output files when multiple jobs terminate at the same time within the same environment.
- it uses the `--provenance` flag on `bosh exec launch` to store a unique job ID in the `additional-information` field of the provenance file.
- provenance file is now moved away from boutiques cache, instead of copied from it, and the related archived descriptor file is removed. These operations are meant to avoid files accumulating over time in boutiques cache, in environments where the same `$HOME` is reused by multiple executions.
- small internal refactoring of `script.sh` to factorize several JSON parsing operations in a new function.
