### PR TITLE
Define HOME when it's not

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>fr.insalyon.creatis</groupId>
     <artifactId>gasw</artifactId>
     <packaging>jar</packaging>
-    <version>3.11.3</version>
+    <version>3.11.4</version>
     <name>GASW</name>
 
     <properties>

--- a/src/main/resources/vm/script/execution/execution.vm
+++ b/src/main/resources/vm/script/execution/execution.vm
@@ -25,6 +25,13 @@ sleep 1
 
 export LD_LIBRARY_PATH=${PWD}:${LD_LIBRARY_PATH}
 
+## Set HOME if not defined.
+## Also set APPTAINER_HOME, so that HOME is set inside singularity containers.
+if [ -z "${HOME}" ]; then
+  export HOME="${PWD}"
+  export APPTAINER_HOME="${PWD}:${PWD}"
+fi
+
 ## The command_line variable is an array to allow spaces in string inputs
 COMMAND_LINE=(./$executableName $parameters)
 


### PR DESCRIPTION
This hotfix sets the `HOME` and `APPTAINER_HOME` variables to `$PWD` when `HOME` is not defined in an execution environment. It allows executions to succeed in such environments, without changing anything in the "normal case" where `HOME` is already set.

It bumps GASW version to 3.11.4.
