### PR TITLE
Define HOME when it's not

### DIFF
--- a/src/main/resources/script.sh
+++ b/src/main/resources/script.sh
@@ -15,6 +15,13 @@ DIRNAME=$(basename "${0%.sh}")
 # Base directory
 BASEDIR="$PWD"
 
+# Set HOME if not defined.
+# Also set APPTAINER_HOME, so that HOME is set inside singularity containers.
+if [ -z "$HOME" ]; then
+  export HOME="$PWD"
+  export APPTAINER_HOME="$PWD:$PWD"
+fi
+
 # Names of the configuration and invocation files
 configurationFilename="$DIRNAME-configuration.sh"
 invocationJsonFilename="$DIRNAME-invocation.json"

--- a/src/main/resources/vm/script/execution/execution.vm
+++ b/src/main/resources/vm/script/execution/execution.vm
@@ -25,6 +25,13 @@ sleep 1
 
 export LD_LIBRARY_PATH=${PWD}:${LD_LIBRARY_PATH}
 
+## Set HOME if not defined.
+## Also set APPTAINER_HOME, so that HOME is set inside singularity containers.
+if [ -z "${HOME}" ]; then
+  export HOME="${PWD}"
+  export APPTAINER_HOME="${PWD}:${PWD}"
+fi
+
 ## The command_line variable is an array to allow spaces in string inputs
 COMMAND_LINE=(./$executableName $parameters)
 


### PR DESCRIPTION
Same as #106, for the `develop` branch, also modifying `script.sh` in addition to `execution.vm`.

This sets the `HOME` and `APPTAINER_HOME` variables to `$PWD` when `HOME` is not defined in an execution environment. It allows executions to succeed in such environments, without changing anything in the "normal case" where `HOME` is already set.
