### PR TITLE
Add directory download for file and lfn inputs

### DIFF
--- a/src/main/resources/script.sh
+++ b/src/main/resources/script.sh
@@ -510,6 +510,7 @@ function downloadLFNdir {
     RET_VAL=1
   fi
 
+  rm get-dir.log
   return ${RET_VAL}
 }
 


### PR DESCRIPTION
Update script.sh to auto-detect when a boutiques input of type `File` is a file or a directory and perform the data transfer accordingly, for the following URI schemes :
- `file:`, using `cp -r`
- `lfn:` (or no scheme), using `dirac-dms-directory-sync`

Behavior when the input is a file is strictly unchanged.
Directory inputs are mounted by `bosh` just as file inputs, and are thus usable within containers.

An example of an app using a directory input is https://github.com/virtual-imaging-platform/vip-apps-boutiques-descriptors/blob/main/GATE_Merger/GATE_Merger-0.3.json
