### PR TITLE
add `force` option on `terminate()`

### DIFF
--- a/src/main/java/fr/insalyon/creatis/gasw/Gasw.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/Gasw.java
@@ -121,13 +121,13 @@ public class Gasw {
      *
      * @throws GaswException
      */
-    public synchronized void terminate() throws GaswException {
+    public synchronized void terminate(boolean force) throws GaswException {
         notification.terminate();
 
         if (GaswConfiguration.getInstance().isFailOverEnabled()) {
             FailOver.getInstance().terminate();
         }
 
-        GaswConfiguration.getInstance().terminate();
+        GaswConfiguration.getInstance().terminate(force);
     }
 }

--- a/src/main/java/fr/insalyon/creatis/gasw/GaswConfiguration.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/GaswConfiguration.java
@@ -383,10 +383,10 @@ public class GaswConfiguration {
      *
      * @throws GaswException
      */
-    public void terminate() throws GaswException {
+    public void terminate(boolean force) throws GaswException {
 
         for (ExecutorPlugin executorPlugin : executorPlugins) {
-            executorPlugin.terminate();
+            executorPlugin.terminate(force);
         }
         for (ListenerPlugin listenerPlugin : listenerPlugins) {
             listenerPlugin.terminate();

--- a/src/main/java/fr/insalyon/creatis/gasw/plugin/ExecutorPlugin.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/plugin/ExecutorPlugin.java
@@ -79,5 +79,5 @@ public interface ExecutorPlugin extends Plugin {
      *
      * @throws GaswException
      */
-    public void terminate() throws GaswException;
+    public void terminate(boolean force) throws GaswException;
 }


### PR DESCRIPTION
This option will help the executor plugin determinate if the workflow shutdown as usually or if it's a kill.
This pull request affect others modules that also need to be updated:
- [vip-workflow-engine](https://github.com/virtual-imaging-platform/vip-workflow-engine/pull/33) pull request
- [gasw-local-plugin](https://github.com/virtual-imaging-platform/GASW-Local-Plugin/pull/16) pull request
- [gasw-batch-plugin](https://github.com/virtual-imaging-platform/GASW-Batch-Plugin/pull/10) pull request
- [gasw-dirac-plugin](https://github.com/virtual-imaging-platform/GASW-Dirac-Plugin/pull/78) pull request
