### PR TITLE
Add --no-pull on bosh exec launch

### DIFF
--- a/src/main/resources/script.sh
+++ b/src/main/resources/script.sh
@@ -815,7 +815,7 @@ function performExec {
   local tmpfolder=$(mktemp -d -p "$PWD" "tmp-XXXXXX")
 
   # Common bosh exec flags
-  local boshopts=("--stream" "--no-automounts")
+  local boshopts=("--stream" "--no-automounts" "--no-pull")
   boshopts+=("--provenance" "{\"jobid\":\"$DIRNAME\"}")
   boshopts+=("-v" "$PWD/../cache:$PWD/../cache")
   boshopts+=("-v" "$tmpfolder:/tmp")


### PR DESCRIPTION
PR https://github.com/boutiques/boutiques/pull/718 has been merged in boutiques `master` branch.

Whenever boutiques 0.5.31 is released, we can enable this flag in GASW `script.sh` to make sure that container images are never implicitly pulled or upgraded on execution nodes.

Side note : `bosh` usage of `argparse` ignores unknown flags unless they are prefixes of other known flags, so in practice specifying `--no-pull` on bosh `0.5.30` and earlier is a no-op, not an error.

